### PR TITLE
fix: add missing logger.warning mock and correct executeSql test 

### DIFF
--- a/server/tests/mcp-server/tools/executeSql/registration.test.ts
+++ b/server/tests/mcp-server/tools/executeSql/registration.test.ts
@@ -104,8 +104,10 @@ describe("Execute SQL Tool Registration", () => {
         description: expect.stringContaining("SQL statements"),
         annotations: expect.objectContaining({
           readOnlyHint: true,
+          destructiveHint: false,
           openWorldHint: false,
-          dangerous: false,
+        }),
+        _meta: expect.objectContaining({
           requiresAuth: true,
         }),
       });

--- a/server/tests/setup.ts
+++ b/server/tests/setup.ts
@@ -6,6 +6,7 @@ vi.mock("../src/utils/internal/logger.js", () => ({
     info: () => {},
     debug: () => {},
     warn: () => {},
+    warning: () => {}, // MCP-specific log level
     error: () => {},
     trace: () => {},
     fatal: () => {},


### PR DESCRIPTION
add missing logger.warning mock and correct executeSql test assertions

Fixed 16 test failures caused by two issues:

1. Missing logger.warning() method in test mock - production code uses logger.warning() but test setup only mocked logger.warn()

2. Incorrect test assertions in executeSql registration test - test expected 'dangerous' property but code uses 'destructiveHint', and 'requiresAuth' is in _meta not annotations

All 290 tests now passing.