### PR TITLE
fix the server deployment issues on power

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # ---- Base Node ----
 # Use a specific Node.js version known to work, Alpine for smaller size
-FROM node:23-alpine AS base
+FROM node:21-alpine AS base
 WORKDIR /usr/src/app
 # NODE_ENV will be set by docker-compose from .env file
 

--- a/apps/mcpgateway/docker-compose.yml
+++ b/apps/mcpgateway/docker-compose.yml
@@ -418,8 +418,8 @@ services:
       - YAML_AUTO_RELOAD=true
       - TOOLS_YAML_PATH=/usr/src/app/tools
     volumes:
-      - ../../tools:/usr/src/app/tools:rw  # Mount tools configurations with read-write for auto-reload
-      - ../../secrets:/usr/src/app/secrets:ro  # Mount secrets directory as read-only
+      - ../../tools:/usr/src/app/tools:rw,Z  # Mount tools configurations with read-write for auto-reload
+      - ../../secrets:/usr/src/app/secrets:ro,Z  # Mount secrets directory as read-only
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3010/health"]
       interval: 30s


### PR DESCRIPTION
1. Change to use the node base image with version 21 which supports ppc64le(This satisfies the node version requirement for ibmi mcp server)
2. Fix the permission issue with the mounted volume by labeling the volume for podman