### PR TITLE
fix: replace deprecated template syntax with named parameters

### DIFF
--- a/tools/security/security-ops.yaml
+++ b/tools/security/security-ops.yaml
@@ -263,7 +263,7 @@ tools:
     statement: |
       SELECT objname, object_audit
         FROM TABLE (qsys2.object_statistics('QSYS', '*CMD'))
-        WHERE objname IN ({{command_names}})
+        WHERE objname IN (:command_names)
     security:
       readOnly: true
     annotations:


### PR DESCRIPTION
Replace deprecated {{command_names}} template syntax with :command_names named parameter syntax in check_command_audit_settings tool.

Fixes #94