### PR TITLE
fix: enforce YAML tool security validation for IBM i authenticated route

### DIFF
--- a/server/src/ibmi-mcp-server/services/authenticatedPoolManager.ts
+++ b/server/src/ibmi-mcp-server/services/authenticatedPoolManager.ts
@@ -19,6 +19,7 @@ import {
   BaseConnectionPool,
   PoolConnectionConfig,
 } from "./baseConnectionPool.js";
+import { SqlToolSecurityConfig } from "@/ibmi-mcp-server/schemas/index.js";
 
 /**
  * Pool configuration options for authenticated sessions
@@ -182,6 +183,7 @@ export class AuthenticatedPoolManager extends BaseConnectionPool<string> {
     query: string,
     params?: BindingValue[],
     context?: RequestContext,
+    securityConfig?: SqlToolSecurityConfig,
   ): Promise<QueryResult<T>> {
     const operationContext =
       context ||
@@ -219,6 +221,7 @@ export class AuthenticatedPoolManager extends BaseConnectionPool<string> {
           query,
           params,
           operationContext,
+          securityConfig,
         );
 
         logger.debug(


### PR DESCRIPTION

Fixes #107

## Solution

1. **Pre-routing validation** (Primary fix)
   - Added validation in SQLToolFactory.executeStatementWithParameters()
   - Validates processed SQL *before* routing decision
   - Applies to both environment and authenticated paths
   - Catches runtime SQL (including direct substitution patterns like :sql)

2. **Authenticated pool security threading**
   - Extended AuthenticatedPoolManager.executeQuery() to accept securityConfig
   - Passes securityConfig through to base pool validation
   - Ensures consistent enforcement at pool boundary