### PR TITLE
fix(cli): enforce read-only security validation for YAML tool execution

### DIFF
--- a/packages/cli/src/commands/tool.ts
+++ b/packages/cli/src/commands/tool.ts
@@ -240,8 +240,19 @@ async function executeTool(
     return;
   }
 
-  // Resolve system and connect
+  // Resolve system and confirm if required
   const resolved = resolveSystem(globalOpts["system"] as string | undefined);
+
+  if (resolved.config.confirm && process.stdin.isTTY) {
+    const { promptPassword } = await import("../config/credentials.js");
+    const answer = await promptPassword(
+      `Execute tool '${name}' on [${resolved.name}]? (y/N) `,
+    );
+    if (answer.toLowerCase() !== "y") {
+      throw new Error("Execution cancelled by user");
+    }
+  }
+
   const cleanup = await connectSystem(resolved);
 
   try {
@@ -258,7 +269,6 @@ async function executeTool(
     let bindingParams: (string | number | (string | number)[])[] = [];
 
     if (tool.parameters.length > 0 && Object.keys(params).length > 0) {
-      // Convert YamlToolParameter[] to the SqlToolParameter shape expected by ParameterProcessor
       const result = await ParameterProcessor.process(
         tool.statement,
         params,
@@ -269,6 +279,25 @@ async function executeTool(
       bindingParams = result.parameters;
     } else {
       processedSql = tool.statement;
+    }
+
+    // Enforce read-only: tool security config + system readOnly override
+    const effectiveReadOnly =
+      (tool.security?.readOnly ?? true) || resolved.config.readOnly;
+
+    if (effectiveReadOnly) {
+      const { SqlSecurityValidator } = await import(
+        "@ibm/ibmi-mcp-server/services"
+      );
+      SqlSecurityValidator.validateQuery(
+        processedSql,
+        {
+          readOnly: true,
+          maxQueryLength: tool.security?.maxQueryLength,
+          forbiddenKeywords: tool.security?.forbiddenKeywords,
+        },
+        ctx,
+      );
     }
 
     // Execute the query

--- a/packages/cli/tests/commands/tool.test.ts
+++ b/packages/cli/tests/commands/tool.test.ts
@@ -1,13 +1,52 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { createProgram } from "../../src/index";
 
 vi.mock("../../src/utils/yaml-loader.js", () => ({
   loadYamlTools: vi.fn(),
 }));
 
+vi.mock("../../src/config/resolver.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/config/resolver.js")>();
+  return {
+    ...actual,
+    resolveSystem: vi.fn(),
+  };
+});
+
+vi.mock("../../src/utils/connection.js", () => ({
+  connectSystem: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+vi.mock("@ibm/ibmi-mcp-server/services", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@ibm/ibmi-mcp-server/services")>();
+  return {
+    ...actual,
+    IBMiConnectionPool: {
+      executeQuery: vi.fn().mockResolvedValue({ data: [{ OK: 1 }] }),
+    },
+    ParameterProcessor: {
+      process: vi.fn().mockResolvedValue({
+        sql: "SELECT 1",
+        parameters: [],
+        parameterNames: [],
+        missingParameters: [],
+        mode: "named",
+        stats: {
+          originalLength: 0,
+          processedLength: 0,
+          namedParametersFound: 0,
+          positionalParametersFound: 0,
+          parametersConverted: 0,
+        },
+      }),
+    },
+  };
+});
+
 describe("ibmi tool command", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
     process.exitCode = undefined;
   });
 
@@ -41,7 +80,7 @@ describe("ibmi tool command", () => {
 
 describe("ibmi --tools global option", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
     process.exitCode = undefined;
   });
 
@@ -55,7 +94,7 @@ describe("ibmi --tools global option", () => {
 
 describe("ibmi tool command — error paths", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
     process.exitCode = undefined;
   });
 
@@ -278,5 +317,146 @@ describe("ibmi tool command — error paths", () => {
       process.stderr.write = originalStderr;
       process.stdout.write = originalStdout;
     }
+  });
+});
+
+describe("ibmi tool command — security validation", () => {
+  let stdoutOutput: string;
+  let stderrOutput: string;
+  const originalStdout = process.stdout.write;
+  const originalStderr = process.stderr.write;
+
+  // Get references to mocked modules at import time
+  let mockLoadYamlTools: ReturnType<typeof vi.fn>;
+  let mockResolveSystem: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    stdoutOutput = "";
+    stderrOutput = "";
+    process.stdout.write = ((chunk: string) => {
+      stdoutOutput += String(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((chunk: string) => {
+      stderrOutput += String(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+
+    const yamlLoader = await import("../../src/utils/yaml-loader.js");
+    mockLoadYamlTools = vi.mocked(yamlLoader.loadYamlTools);
+
+    const resolver = await import("../../src/config/resolver.js");
+    mockResolveSystem = vi.mocked(resolver.resolveSystem);
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalStdout;
+    process.stderr.write = originalStderr;
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+  });
+
+  function mockToolWithStatement(
+    statement: string,
+    security?: { readOnly?: boolean },
+    systemReadOnly = false,
+  ) {
+    mockLoadYamlTools.mockReturnValue({
+      tools: {
+        test_tool: {
+          source: "test",
+          description: "Test tool",
+          statement,
+          parameters: [],
+          ...(security !== undefined ? { security } : {}),
+        },
+      },
+      toolsets: {},
+      sources: {},
+    });
+
+    mockResolveSystem.mockReturnValue({
+      name: "dev",
+      config: {
+        host: "dev400.com",
+        port: 8076,
+        user: "DEV",
+        readOnly: systemReadOnly,
+        confirm: false,
+        timeout: 60,
+        maxRows: 5000,
+        ignoreUnauthorized: true,
+      },
+      source: "flag",
+    });
+  }
+
+  it("should block DELETE when tool has security.readOnly: true", async () => {
+    mockToolWithStatement("DELETE FROM SAMPLE.EMPLOYEE WHERE EMPNO = '999'", { readOnly: true });
+
+    const program = createProgram();
+    program.exitOverride();
+    await program.parseAsync([
+      "node", "ibmi", "tool", "test_tool", "--tools", "/fake.yaml",
+    ]);
+
+    const output = stdoutOutput + stderrOutput;
+    expect(output).toMatch(/write operation/i);
+  });
+
+  it("should block INSERT when tool has no security config (defaults to readOnly)", async () => {
+    mockToolWithStatement("INSERT INTO SAMPLE.EMPLOYEE VALUES ('X')");
+
+    const program = createProgram();
+    program.exitOverride();
+    await program.parseAsync([
+      "node", "ibmi", "tool", "test_tool", "--tools", "/fake.yaml",
+    ]);
+
+    const output = stdoutOutput + stderrOutput;
+    expect(output).toMatch(/write operation/i);
+  });
+
+  it("should allow SELECT when tool has security.readOnly: true", async () => {
+    mockToolWithStatement("SELECT * FROM SYSIBM.SYSDUMMY1", { readOnly: true });
+
+    const program = createProgram();
+    program.exitOverride();
+    await program.parseAsync([
+      "node", "ibmi", "tool", "test_tool", "--tools", "/fake.yaml",
+    ]);
+
+    const output = stdoutOutput + stderrOutput;
+    expect(output).not.toMatch(/write operation/i);
+  });
+
+  it("should allow DELETE when tool has security.readOnly: false", async () => {
+    mockToolWithStatement("DELETE FROM SAMPLE.EMPLOYEE WHERE 1=0", { readOnly: false });
+
+    const program = createProgram();
+    program.exitOverride();
+    await program.parseAsync([
+      "node", "ibmi", "tool", "test_tool", "--tools", "/fake.yaml",
+    ]);
+
+    const output = stdoutOutput + stderrOutput;
+    expect(output).not.toMatch(/write operation/i);
+  });
+
+  it("should block DELETE when system readOnly overrides tool readOnly: false", async () => {
+    mockToolWithStatement(
+      "DELETE FROM SAMPLE.EMPLOYEE WHERE 1=0",
+      { readOnly: false },
+      true, // system readOnly
+    );
+
+    const program = createProgram();
+    program.exitOverride();
+    await program.parseAsync([
+      "node", "ibmi", "tool", "test_tool", "--tools", "/fake.yaml",
+    ]);
+
+    const output = stdoutOutput + stderrOutput;
+    expect(output).toMatch(/write operation/i);
   });
 });


### PR DESCRIPTION
## Summary

- **Fix security gap**: `ibmi tool` loaded YAML `security.readOnly` config but never enforced it — SQL executed without validation
- **Add SqlSecurityValidator**: Validate processed SQL against tool security config before executing queries
- **Safe defaults**: Tools without explicit `security` config default to `readOnly: true`
- **System override**: System-level `readOnly: true` overrides tool `readOnly: false` (most restrictive wins)
- **Confirm prompt**: Respect system `confirm` flag for interactive confirmation (parity with `ibmi sql`)

### Security Matrix

| Tool `readOnly` | System `readOnly` | Mutation SQL | Result |
|----------------|-------------------|-------------|--------|
| `true` | `false` | `DELETE` | Blocked |
| *(none — defaults true)* | `false` | `INSERT` | Blocked |
| `true` | `false` | `SELECT` | Allowed |
| `false` | `false` | `DELETE` | Allowed |
| `false` | `true` | `DELETE` | Blocked (system override) |

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — no issues
- [x] `npm test` — 734/734 tests pass (+5 new security tests)
- [x] Manual: `ibmi tool` with readOnly tool blocks DELETE/INSERT
- [x] Manual: tool with no security config defaults to readOnly
- [x] Manual: tool with `readOnly: false` allows mutations
- [x] Manual: system `readOnly: true` overrides tool `readOnly: false`