### PR TITLE
feat(config): general-purpose jdbc-options field (supersedes #138)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,15 @@ DB2i_PORT=8076
 # ⚠️ SECURITY: Set to false in production with valid SSL certificates
 DB2i_IGNORE_UNAUTHORIZED=true
 
+# Mapepire JDBC connection options (optional)
+# Format: semicolon-separated key=value pairs (matches DB2 JDBC URL syntax)
+# - Keys with spaces are allowed (e.g., "date format")
+# - The "libraries" value is comma-separated (the only array-valued option)
+# - All other values are forwarded as strings to the JDBC driver
+# - Overrides any jdbc-options set in YAML sources
+# Example: DB2i_JDBC_OPTIONS='naming=system;date format=iso;libraries=MYLIB,DEVDATA'
+DB2i_JDBC_OPTIONS=
+
 # -----------------------------------------------------------------------------
 # 🧩 YAML Tool Configuration
 # -----------------------------------------------------------------------------

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -528,6 +528,7 @@ Below is the reference for core server configuration options. Each section inclu
 | `DB2i_PASS` | IBM i user password | (none) | `mypassword` | Never commit to version control |
 | `DB2i_PORT` | Mapepire daemon port | `8076` | `8076` | Ensure firewall allows this port |
 | `DB2i_IGNORE_UNAUTHORIZED` | Skip TLS certificate verification | `true` | `false` | ⚠️ **High Risk**: Set `false` in production |
+| `DB2i_JDBC_OPTIONS` | Mapepire JDBC options ([syntax](#db2i-jdbc-options-env-var)) | (none) | `naming=system;date format=iso` | `key ring password` redacted from logs |
 
 <Warning>
 **Security Alert**: `DB2i_IGNORE_UNAUTHORIZED=true` disables TLS certificate verification, making connections vulnerable to man-in-the-middle attacks.
@@ -565,6 +566,105 @@ Below is the reference for core server configuration options. Each section inclu
 - Access to QSYS2 system services
 - Mapepire daemon must be running on the specified port
 </Note>
+
+### DB2i_JDBC_OPTIONS Env Var
+
+**Forward any [mapepire JDBC option](https://javadoc.io/static/net.sf.jt400/jt400/21.0.0/com/ibm/as400/access/doc-files/JDBCProperties.html) to the underlying driver via a single environment variable.** The `DB2i_JDBC_OPTIONS` env var accepts a semicolon-separated list of `key=value` pairs modeled on DB2 JDBC URL syntax — letting you set library list, naming convention, date format, and any other JDBC property without editing YAML.
+
+```bash
+DB2i_JDBC_OPTIONS='naming=system;date format=iso;libraries=MYLIB,DEVDATA'
+```
+
+#### Format Rules
+
+| Rule | Behavior |
+|------|----------|
+| Outer separator | `;` splits pairs; empty segments are ignored |
+| Inner separator | First `=` in each pair splits key/value (values may contain `=`) |
+| Whitespace | Trimmed around both key and value |
+| Arrays | Only `libraries` is array-valued; comma-split within a single pair |
+| Types | All other values forwarded as strings — no boolean/number coercion |
+| Keys with spaces | Work unquoted: `date format=iso` is valid |
+| Malformed pairs | A non-empty segment with no `=` throws a clear error at startup |
+
+<Tabs>
+  <Tab title="Library List">
+    ```bash
+    DB2i_JDBC_OPTIONS='libraries=MYLIB,DEVDATA,QGPL'
+    ```
+
+    **Use for**: Resolving unqualified object names. Comma-split within the single `libraries=` pair.
+  </Tab>
+
+  <Tab title="Date Format">
+    ```bash
+    DB2i_JDBC_OPTIONS='date format=iso'
+    ```
+
+    **Output**: `SELECT CHAR(CURRENT_DATE)` → `2026-04-17`
+
+    **Other values**: `usa` (`04/17/2026`), `eur` (`17.04.2026`), `jis` (`2026-04-17`), `mdy`, `dmy`, `ymd`, `julian`
+
+    <Warning>
+    **Job default caveat**: If `date format` is unset, the driver inherits the connected job's `DATFMT` system value — which may produce **two-digit years** (e.g., `04/17/26`). Set `date format=iso` explicitly for unambiguous date serialization.
+    </Warning>
+  </Tab>
+
+  <Tab title="Combined Options">
+    ```bash
+    DB2i_JDBC_OPTIONS='naming=system;date format=iso;libraries=REPORTS,SALESDATA,QGPL'
+    ```
+
+    **Use for**: Reporting or audit pipelines that need a specific library list, legacy slash-notation naming, and ISO date format.
+  </Tab>
+</Tabs>
+
+#### Precedence and YAML Interaction
+
+`DB2i_JDBC_OPTIONS` is **shallow-merged over** the `jdbc-options` field in each YAML source. Env values win on per-key collisions; YAML-only keys are preserved.
+
+| Scenario | Result |
+|----------|--------|
+| Only YAML sets `jdbc-options` | YAML values flow through unchanged |
+| Only env sets `DB2i_JDBC_OPTIONS` | Env values apply to every source |
+| Both set the same key | **Env wins** for that key |
+| Both set different keys | Both apply (shallow merge, union of keys) |
+
+<Info>
+**Why env overrides YAML**: Operators can enforce a fleet-wide JDBC configuration (for example, forcing `naming=system` or a standard library list across all environments) without editing per-deployment YAML files.
+</Info>
+
+**Example merge:**
+
+```yaml
+# YAML source
+jdbc-options:
+  libraries: [YAMLLIB]
+  naming: sql
+  date format: iso
+```
+
+```bash
+# Env var
+DB2i_JDBC_OPTIONS='libraries=ENVLIB;naming=system'
+```
+
+```yaml
+# Effective JDBC options sent to mapepire
+libraries: [ENVLIB]      # env wins
+naming: system           # env wins
+date format: iso         # YAML only, preserved
+```
+
+#### Security: Log Redaction
+
+The server logs **only** the `libraries` field at pool initialization. Other JDBC fields — including potentially sensitive values like `key ring password`, `proxy server`, and `trace` — are **intentionally excluded** from every log level to prevent credential leakage.
+
+<Note>
+If you need to verify that a non-`libraries` option took effect, inspect driver behavior directly (for example, run `SELECT CHAR(CURRENT_DATE)` to confirm `date format`) rather than searching the logs.
+</Note>
+
+See the [YAML Sources Reference → JDBC Options](/sql-tools/sources#jdbc-options) for per-source configuration in YAML.
 
 ## SQL Tools Configuration
 

--- a/docs/sql-tools/sources.mdx
+++ b/docs/sql-tools/sources.mdx
@@ -20,6 +20,7 @@ Sources define database connections that your SQL tools use to execute queries a
 | `password` | string | ✅ Yes | - | User profile password |
 | `port` | integer | No | `8076` | Mapepire daemon port |
 | `ignore-unauthorized` | boolean | No | `false` | Accept self-signed SSL certs |
+| `jdbc-options` | object | No | `{}` | JDBC connection options passed to the mapepire driver (libraries, naming, date format, etc.) |
 
 ---
 
@@ -134,6 +135,7 @@ These fields have sensible defaults and can be omitted for most configurations:
 |-------|------|---------|-------------|
 | `port` | integer | `8076` | Port number where Mapepire daemon listens |
 | `ignore-unauthorized` | boolean | `false` | Accept self-signed SSL certificates |
+| `jdbc-options` | object | `{}` | JDBC connection options forwarded to the mapepire driver |
 
 **Detailed Configuration:**
 
@@ -213,6 +215,131 @@ These fields have sensible defaults and can be omitted for most configurations:
     </Warning>
   </Tab>
 </Tabs>
+
+---
+
+## JDBC Options
+
+**Forward any [mapepire JDBC option](https://javadoc.io/static/net.sf.jt400/jt400/21.0.0/com/ibm/as400/access/doc-files/JDBCProperties.html) to the underlying driver.** The `jdbc-options` field accepts any property supported by the IBM i JDBC driver — library list, SQL naming convention, date format, time format, and many more.
+
+### Common Options
+
+| Option | Purpose | Example |
+|--------|---------|---------|
+| `libraries` | Library list for unqualified name resolution | `[MYLIB, DEVDATA, QGPL]` |
+| `naming` | SQL naming convention | `sql` or `system` |
+| `date format` | Date literal format | `iso`, `usa`, `eur`, `jis`, `mdy`, `dmy`, `ymd`, `julian` |
+| `time format` | Time literal format | `hms`, `usa`, `iso`, `eur`, `jis` |
+| `date separator` | Date component separator | `/`, `-`, `.`, `,`, `b` |
+
+<Tabs>
+  <Tab title="Library List">
+    ```yaml
+    sources:
+      ibmi-dev:
+        host: ${DB2i_HOST}
+        user: ${DB2i_USER}
+        password: ${DB2i_PASS}
+        jdbc-options:
+          libraries:
+            - MYLIB
+            - DEVDATA
+            - QGPL
+    ```
+
+    **Use for**: Resolving unqualified object names against a specific set of libraries.
+
+    <Note>
+    `libraries` also accepts a comma-separated string: `libraries: "MYLIB, DEVDATA, QGPL"` — the server splits and trims it into an array.
+    </Note>
+  </Tab>
+
+  <Tab title="Date Format">
+    ```yaml
+    sources:
+      ibmi-iso:
+        host: ${DB2i_HOST}
+        user: ${DB2i_USER}
+        password: ${DB2i_PASS}
+        jdbc-options:
+          date format: iso    # YYYY-MM-DD
+    ```
+
+    **Output**: `CURRENT_DATE` → `2026-04-17` (ISO 8601)
+
+    **Other formats:**
+    - `usa` → `04/17/2026` (MM/DD/YYYY)
+    - `eur` → `17.04.2026` (DD.MM.YYYY)
+    - `jis` → `2026-04-17` (same as ISO)
+
+    <Warning>
+    **Job default caveat**: If you don't set `date format`, the driver inherits the connected job's `DATFMT` system value — which on many systems produces **two-digit years** (e.g., `04/17/26`). Set `date format: iso` explicitly if unambiguous serialization matters to your application.
+    </Warning>
+  </Tab>
+
+  <Tab title="SQL Naming">
+    ```yaml
+    sources:
+      ibmi-system:
+        host: ${DB2i_HOST}
+        user: ${DB2i_USER}
+        password: ${DB2i_PASS}
+        jdbc-options:
+          naming: system   # LIBRARY/OBJECT syntax
+    ```
+
+    **Use for**: Legacy SQL using `LIBRARY/OBJECT` slash-notation instead of standard `LIBRARY.OBJECT` dot-notation.
+
+    **Values:**
+    - `sql` (default) — standard `SCHEMA.OBJECT`
+    - `system` — IBM i legacy `LIBRARY/OBJECT`
+  </Tab>
+
+  <Tab title="Combined">
+    ```yaml
+    sources:
+      ibmi-reporting:
+        host: ${DB2i_HOST}
+        user: ${DB2i_USER}
+        password: ${DB2i_PASS}
+        jdbc-options:
+          libraries: [REPORTS, SALESDATA, QGPL]
+          naming: system
+          date format: iso
+          time format: iso
+    ```
+
+    **Use for**: Reporting pipelines that need ISO-formatted dates and access to a specific library set.
+  </Tab>
+</Tabs>
+
+### Full Property List
+
+The field accepts any property from the mapepire `JDBCOptions` interface — over 60 settings covering SQL behavior, date/time formatting, locale, tracing, and more. Refer to the [IBM i JDBC properties reference](https://javadoc.io/static/net.sf.jt400/jt400/21.0.0/com/ibm/as400/access/doc-files/JDBCProperties.html) for the complete catalog.
+
+<Info>
+**Passthrough validation**: Unknown keys pass through the schema validator without error and are forwarded to the driver as-is. This is intentional — it avoids coupling the schema to the driver's exact property surface. The tradeoff is that typos (e.g., `librarys` instead of `libraries`) are silently accepted at config load time and only surface when the driver rejects them at connection time.
+</Info>
+
+### Environment Variable Override
+
+The `DB2i_JDBC_OPTIONS` environment variable overrides `jdbc-options` set in YAML — operators can enforce a fleet-wide JDBC configuration without editing per-deployment YAML. Env values are shallow-merged over YAML values (env wins on each key).
+
+```bash
+# Every source in every YAML file runs with these options,
+# plus whatever is set per-source in YAML (env wins on collisions)
+export DB2i_JDBC_OPTIONS='naming=system;date format=iso;libraries=AUDITLIB,QGPL'
+```
+
+See the [Configuration Reference → DB2i_JDBC_OPTIONS](/configuration#db2i-jdbc-options-env-var) for the full syntax and parser rules.
+
+### Security: Credential Logging
+
+The server logs only the `libraries` field of `jdbc-options` at pool initialization. All other JDBC fields — including potentially sensitive ones like `key ring password`, `proxy server`, and `trace` — are **intentionally excluded** from logs to prevent credential leakage.
+
+<Note>
+If you need to verify other JDBC options took effect, query the JDBC driver's runtime metadata (for example, execute `SELECT CURRENT_DATE` and inspect the format) rather than relying on log inspection.
+</Note>
 
 ---
 

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -30,6 +30,15 @@ DB2i_PORT=8076
 # ⚠️ SECURITY: Set to false in production with valid SSL certificates
 DB2i_IGNORE_UNAUTHORIZED=true
 
+# Mapepire JDBC connection options (optional)
+# Format: semicolon-separated key=value pairs (matches DB2 JDBC URL syntax)
+# - Keys with spaces are allowed (e.g., "date format")
+# - The "libraries" value is comma-separated (the only array-valued option)
+# - All other values are forwarded as strings to the JDBC driver
+# - Overrides any jdbc-options set in YAML sources
+# Example: DB2i_JDBC_OPTIONS='naming=system;date format=iso;libraries=MYLIB,DEVDATA'
+DB2i_JDBC_OPTIONS=
+
 # -----------------------------------------------------------------------------
 # 🧩 YAML Tool Configuration
 # -----------------------------------------------------------------------------

--- a/packages/server/src/config/index.ts
+++ b/packages/server/src/config/index.ts
@@ -13,6 +13,7 @@ import { homedir } from "os";
 import path, { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { z } from "zod";
+import type { JDBCOptions } from "@ibm/mapepire-js";
 
 // Load .env from multiple possible locations for monorepo flexibility
 // Priority order:
@@ -260,6 +261,13 @@ const EnvSchema = z.object({
     .default("true")
     .transform((val) => val === "true" || val === "1"),
 
+  /**
+   * Mapepire JDBC connection options. Semicolon-separated key=value pairs
+   * modeled on DB2 JDBC URL syntax. From `DB2i_JDBC_OPTIONS`.
+   * Example: `naming=system;date format=iso;libraries=MYLIB,DEVDATA`
+   */
+  DB2i_JDBC_OPTIONS: z.string().optional(),
+
   /** Path to YAML tools configuration file. From `TOOLS_YAML_PATH`. */
   TOOLS_YAML_PATH: z
     .string()
@@ -495,6 +503,55 @@ if (!validatedLogsPath) {
   }
 }
 
+/**
+ * Parse DB2i_JDBC_OPTIONS env var: a semicolon-separated list of key=value
+ * pairs modeled on DB2 JDBC URL syntax.
+ *
+ * Example: `naming=system;date format=iso;libraries=MYLIB,DEVDATA`
+ *
+ * Rules:
+ *   - `;` splits outer pairs; empty segments are ignored
+ *   - First `=` in each pair splits key/value (values may contain `=`)
+ *   - Whitespace around key and value is trimmed
+ *   - `libraries` is comma-split into string[] (only array-valued JDBCOption)
+ *   - All other values are forwarded as strings — mapepire's JDBC driver
+ *     accepts string values for all options; no bool/number coercion
+ *   - Malformed pairs (non-empty with no `=`) throw to surface typos early
+ */
+function parseJdbcOptionsString(raw: string): JDBCOptions | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  const result: Record<string, unknown> = {};
+  for (const segment of trimmed.split(";")) {
+    const pair = segment.trim();
+    if (!pair) continue;
+    const eqIdx = pair.indexOf("=");
+    if (eqIdx === -1) {
+      throw new Error(
+        `Invalid DB2i_JDBC_OPTIONS: malformed pair "${pair}" — expected key=value`,
+      );
+    }
+    const key = pair.slice(0, eqIdx).trim();
+    const value = pair.slice(eqIdx + 1).trim();
+    if (!key) {
+      throw new Error(
+        `Invalid DB2i_JDBC_OPTIONS: empty key in pair "${pair}"`,
+      );
+    }
+    if (key === "libraries") {
+      result[key] = value
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else {
+      result[key] = value;
+    }
+  }
+  return Object.keys(result).length > 0
+    ? (result as JDBCOptions)
+    : undefined;
+}
+
 export const config = {
   pkg,
   mcpServerName: env.MCP_SERVER_NAME || pkg.name,
@@ -575,18 +632,29 @@ export const config = {
    * through the static import chain (logger → utils → config).
    */
   get db2i():
-    | { host: string; user: string; password: string; ignoreUnauthorized: boolean }
+    | {
+        host: string;
+        user: string;
+        password: string;
+        ignoreUnauthorized: boolean;
+        jdbcOptions?: JDBCOptions;
+      }
     | undefined {
     const host = process.env.DB2i_HOST;
     const user = process.env.DB2i_USER;
     const password = process.env.DB2i_PASS;
     if (!host || !user || !password) return undefined;
     const ignoreRaw = process.env.DB2i_IGNORE_UNAUTHORIZED ?? "true";
+    const rawJdbcOptions = process.env.DB2i_JDBC_OPTIONS;
+    const jdbcOptions = rawJdbcOptions
+      ? parseJdbcOptionsString(rawJdbcOptions)
+      : undefined;
     return {
       host,
       user,
       password,
       ignoreUnauthorized: ignoreRaw === "true" || ignoreRaw === "1",
+      ...(jdbcOptions ? { jdbcOptions } : {}),
     };
   },
 

--- a/packages/server/src/ibmi-mcp-server/schemas/config.ts
+++ b/packages/server/src/ibmi-mcp-server/schemas/config.ts
@@ -96,6 +96,35 @@ export const SourceConfigSchema = z
       .boolean()
       .optional()
       .describe("Whether to ignore unauthorized SSL certificates"),
+    // `.passthrough()` lets any JDBCOption flow through without enumerating
+    // 60+ properties in Zod. Tradeoff: typos (e.g., `librarys`) pass
+    // validation and are silently forwarded to mapepire. Intentional — an
+    // exhaustive enum would couple us to mapepire's type surface and break
+    // on upstream additions.
+    "jdbc-options": z
+      .object({
+        libraries: z
+          .union([
+            z.array(z.string().min(1)),
+            z
+              .string()
+              .transform((val) =>
+                val
+                  .split(",")
+                  .map((s) => s.trim())
+                  .filter(Boolean),
+              ),
+          ])
+          .optional(),
+      })
+      .passthrough()
+      .optional()
+      .describe(
+        "JDBC connection options passed to the mapepire connection pool. " +
+          "Supports any mapepire JDBCOption (libraries, naming, date format, etc.). " +
+          "The 'libraries' field accepts an array or comma-separated string. " +
+          "Env var DB2i_JDBC_OPTIONS overrides these values per-source.",
+      ),
   })
   .describe("Database connection configuration");
 

--- a/packages/server/src/ibmi-mcp-server/schemas/json/sql-tools-config.json
+++ b/packages/server/src/ibmi-mcp-server/schemas/json/sql-tools-config.json
@@ -34,9 +34,34 @@
               "ignore-unauthorized": {
                 "type": "boolean",
                 "description": "Whether to ignore unauthorized SSL certificates"
+              },
+              "jdbc-options": {
+                "type": "object",
+                "properties": {
+                  "libraries": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": true,
+                "description": "JDBC connection options passed to the mapepire connection pool. Supports any mapepire JDBCOption (libraries, naming, date format, etc.). The 'libraries' field accepts an array or comma-separated string. Env var DB2i_JDBC_OPTIONS overrides these values per-source."
               }
             },
-            "required": ["host", "user", "password"],
+            "required": [
+              "host",
+              "user",
+              "password"
+            ],
             "additionalProperties": false,
             "description": "Database connection configuration"
           },
@@ -122,7 +147,12 @@
                     },
                     "itemType": {
                       "type": "string",
-                      "enum": ["string", "boolean", "integer", "float"],
+                      "enum": [
+                        "string",
+                        "boolean",
+                        "integer",
+                        "float"
+                      ],
                       "description": "Array item type (only for array parameters)"
                     },
                     "min": {
@@ -144,7 +174,11 @@
                     "enum": {
                       "type": "array",
                       "items": {
-                        "type": ["string", "number", "boolean"]
+                        "type": [
+                          "string",
+                          "number",
+                          "boolean"
+                        ]
                       },
                       "description": "Valid values (enum validation)"
                     },
@@ -153,7 +187,10 @@
                       "description": "Custom validation pattern (regex for strings)"
                     }
                   },
-                  "required": ["name", "type"],
+                  "required": [
+                    "name",
+                    "type"
+                  ],
                   "additionalProperties": false,
                   "description": "SQL tool parameter definition with validation constraints"
                 },
@@ -174,7 +211,10 @@
               },
               "responseFormat": {
                 "type": "string",
-                "enum": ["json", "markdown"],
+                "enum": [
+                  "json",
+                  "markdown"
+                ],
                 "description": "Response format (default: json)"
               },
               "annotations": {
@@ -247,7 +287,12 @@
               },
               "tableFormat": {
                 "type": "string",
-                "enum": ["markdown", "ascii", "grid", "compact"],
+                "enum": [
+                  "markdown",
+                  "ascii",
+                  "grid",
+                  "compact"
+                ],
                 "default": "markdown",
                 "description": "Table formatting style for SQL results (default: markdown). Options: markdown (GitHub-style), ascii (plain text), grid (Unicode boxes), compact (minimal spacing)"
               },
@@ -275,7 +320,10 @@
                 "description": "@deprecated Use annotations.openWorldHint instead"
               }
             },
-            "required": ["source", "description"],
+            "required": [
+              "source",
+              "description"
+            ],
             "additionalProperties": false,
             "description": "Individual SQL tool definition in YAML configuration"
           },
@@ -311,7 +359,9 @@
                 "description": "Optional toolset metadata"
               }
             },
-            "required": ["tools"],
+            "required": [
+              "tools"
+            ],
             "additionalProperties": false,
             "description": "Toolset definition for grouping related tools"
           },
@@ -349,7 +399,10 @@
                 "description": "Whether this tool should be added to ALL toolsets"
               }
             },
-            "required": ["domain", "category"],
+            "required": [
+              "domain",
+              "category"
+            ],
             "additionalProperties": false,
             "description": "TypeScript tool configuration for toolset assignment"
           },

--- a/packages/server/src/ibmi-mcp-server/services/baseConnectionPool.ts
+++ b/packages/server/src/ibmi-mcp-server/services/baseConnectionPool.ts
@@ -6,6 +6,7 @@
  */
 
 import pkg, { BindingValue, QueryResult, DaemonServer } from "@ibm/mapepire-js";
+import type { JDBCOptions } from "@ibm/mapepire-js";
 const { Pool, getRootCertificate } = pkg;
 import { ErrorHandler, logger } from "@/utils/internal/index.js";
 import {
@@ -33,6 +34,7 @@ export interface PoolConnectionConfig {
   ignoreUnauthorized?: boolean;
   maxSize?: number;
   startingSize?: number;
+  jdbcOptions?: JDBCOptions;
 }
 
 /**
@@ -190,6 +192,13 @@ export abstract class BaseConnectionPool<TId extends string | symbol = string> {
           port: poolState.config.port || 8471,
           user: poolState.config.user.substring(0, 3) + "***",
           ignoreUnauthorized: poolState.config.ignoreUnauthorized ?? true,
+          // Intentionally logging only `libraries`: other JDBCOptions fields
+          // (e.g., "key ring password", "proxy server") may contain sensitive
+          // values. Revisit if we add structured redaction for the full
+          // jdbcOptions object.
+          ...(poolState.config.jdbcOptions?.libraries?.length
+            ? { libraries: poolState.config.jdbcOptions.libraries }
+            : {}),
         },
         `Initializing connection pool: ${String(poolId).substring(0, 7)}***`,
       );
@@ -202,6 +211,10 @@ export abstract class BaseConnectionPool<TId extends string | symbol = string> {
         creds: server,
         maxSize: poolState.config.maxSize || 10,
         startingSize: poolState.config.startingSize || 2,
+        ...(poolState.config.jdbcOptions &&
+        Object.keys(poolState.config.jdbcOptions).length > 0
+          ? { opts: poolState.config.jdbcOptions }
+          : {}),
       });
 
       await poolState.pool.init();

--- a/packages/server/src/ibmi-mcp-server/services/connectionPool.ts
+++ b/packages/server/src/ibmi-mcp-server/services/connectionPool.ts
@@ -86,6 +86,9 @@ export class IBMiConnectionPool extends BaseConnectionPool<
         user,
         password,
         ignoreUnauthorized,
+        ...(config.db2i.jdbcOptions
+          ? { jdbcOptions: config.db2i.jdbcOptions }
+          : {}),
       };
 
       // Initialize the pool using base class

--- a/packages/server/src/ibmi-mcp-server/services/sourceManager.ts
+++ b/packages/server/src/ibmi-mcp-server/services/sourceManager.ts
@@ -6,6 +6,8 @@
  */
 
 import { BindingValue, QueryResult } from "@ibm/mapepire-js";
+import type { JDBCOptions } from "@ibm/mapepire-js";
+import { config } from "@/config/index.js";
 import {
   SourceConfig,
   SqlToolSecurityConfig,
@@ -78,6 +80,22 @@ export class SourceManager extends BaseConnectionPool<string> {
           `Registering source: ${sourceName}`,
         );
 
+        // ENV overrides YAML: operators can enforce a fleet-wide JDBC config
+        // without editing YAML files per deployment. Shallow merge is
+        // sufficient — JDBCOptions is a flat object with no nested fields.
+        //
+        // `as JDBCOptions` cast: Zod's `.passthrough()` infers
+        // `{ libraries?: string[] } & { [key: string]: unknown }`, which is
+        // structurally compatible but not identical to the interface.
+        const yamlJdbc = sourceConfig["jdbc-options"] as
+          | JDBCOptions
+          | undefined;
+        const envJdbc = config.db2i?.jdbcOptions;
+        const mergedJdbc: JDBCOptions | undefined =
+          yamlJdbc || envJdbc
+            ? { ...(yamlJdbc ?? {}), ...(envJdbc ?? {}) }
+            : undefined;
+
         // Convert YAML source to pool connection config
         const poolConfig: PoolConnectionConfig = {
           host: sourceConfig.host,
@@ -85,6 +103,9 @@ export class SourceManager extends BaseConnectionPool<string> {
           password: sourceConfig.password,
           port: sourceConfig.port,
           ignoreUnauthorized: sourceConfig["ignore-unauthorized"],
+          ...(mergedJdbc && Object.keys(mergedJdbc).length > 0
+            ? { jdbcOptions: mergedJdbc }
+            : {}),
         };
 
         // Store the original source config for reference

--- a/packages/server/tests/ibmi-mcp-server/services/jdbcOptions.test.ts
+++ b/packages/server/tests/ibmi-mcp-server/services/jdbcOptions.test.ts
@@ -1,0 +1,834 @@
+/**
+ * @fileoverview Tests for jdbc-options configuration across all layers
+ * Covers: DB2i_JDBC_OPTIONS env var parsing, YAML schema validation,
+ * PoolConnectionConfig wiring, mapepire Pool JDBC options, SourceManager
+ * registration (with env-over-YAML merge), and IBMiConnectionPool.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { PoolConnectionConfig } from "../../../src/ibmi-mcp-server/services/baseConnectionPool.js";
+
+// ---------------------------------------------------------------------------
+// Hoisted mock state – vi.hoisted runs before vi.mock factories
+// ---------------------------------------------------------------------------
+const { mockPoolInstance, MockPool, mockGetRootCert } = vi.hoisted(() => {
+  const mockPoolInstance = {
+    init: vi.fn(),
+    execute: vi.fn(),
+    end: vi.fn(),
+    query: vi.fn(),
+  };
+  return {
+    mockPoolInstance,
+    MockPool: vi.fn(() => mockPoolInstance),
+    mockGetRootCert: vi.fn().mockResolvedValue("cert"),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+vi.mock("../../../src/utils/scheduling/index.js", () => ({
+  SchedulerService: { getInstance: vi.fn() },
+  schedulerService: {},
+}));
+
+vi.mock("@ibm/mapepire-js", () => ({
+  default: {
+    Pool: MockPool,
+    getRootCertificate: mockGetRootCert,
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+import { BaseConnectionPool } from "../../../src/ibmi-mcp-server/services/baseConnectionPool.js";
+import { SourceManager } from "../../../src/ibmi-mcp-server/services/sourceManager.js";
+import {
+  SourceConfigSchema,
+  SqlToolsConfigSchema,
+} from "../../../src/ibmi-mcp-server/schemas/config.js";
+import { config } from "../../../src/config/index.js";
+import { logger } from "../../../src/utils/internal/index.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+class TestConnectionPool extends BaseConnectionPool<string> {
+  async testInitializePool(
+    poolId: string,
+    poolConfig: PoolConnectionConfig,
+    context: Record<string, unknown>,
+  ) {
+    return this.initializePool(poolId, poolConfig, context as never);
+  }
+
+  async testExecuteQuery(
+    poolId: string,
+    query: string,
+    params?: unknown[],
+    context?: Record<string, unknown>,
+  ) {
+    return this.executeQuery(
+      poolId,
+      query,
+      params as never,
+      context as never,
+    );
+  }
+
+  getPoolsMap() {
+    return this.pools;
+  }
+}
+
+class TestSourceManager extends SourceManager {
+  getPoolsMap() {
+    return this.pools;
+  }
+}
+
+const BASE_CONFIG: PoolConnectionConfig = {
+  host: "test-host",
+  user: "testuser",
+  password: "testpass",
+  port: 8076,
+  ignoreUnauthorized: true,
+};
+
+const TEST_CONTEXT = {
+  requestId: "jdbc-options-test",
+  timestamp: new Date().toISOString(),
+  operation: "Test",
+};
+
+const SUCCESSFUL_RESULT = {
+  success: true,
+  data: [{ result: 1 }],
+  sql_rc: 0,
+  execution_time: 50,
+};
+
+const ORIGINAL_IDLE_TIMEOUT = config.poolTimeouts.idleTimeoutMs;
+const ORIGINAL_QUERY_TIMEOUT = config.poolTimeouts.queryTimeoutMs;
+
+function resetMocks() {
+  MockPool.mockClear();
+  mockPoolInstance.init.mockReset().mockResolvedValue(undefined);
+  mockPoolInstance.execute.mockReset().mockResolvedValue(SUCCESSFUL_RESULT);
+  mockPoolInstance.end.mockReset().mockResolvedValue(undefined);
+  mockPoolInstance.query.mockReset();
+  mockGetRootCert.mockClear();
+}
+
+function restoreConfig() {
+  config.poolTimeouts.idleTimeoutMs = ORIGINAL_IDLE_TIMEOUT;
+  config.poolTimeouts.queryTimeoutMs = ORIGINAL_QUERY_TIMEOUT;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Group 1 – SourceConfigSchema jdbc-options validation
+// ═══════════════════════════════════════════════════════════════════════════
+describe("SourceConfigSchema – jdbc-options field", () => {
+  const base = { host: "myhost", user: "myuser", password: "mypass" };
+
+  it("1.1 – accepts libraries as an array of names", () => {
+    const result = SourceConfigSchema.safeParse({
+      ...base,
+      "jdbc-options": { libraries: ["MYLIB", "DEVDATA", "QGPL"] },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data["jdbc-options"]?.libraries).toEqual([
+        "MYLIB",
+        "DEVDATA",
+        "QGPL",
+      ]);
+    }
+  });
+
+  it("1.2 – accepts libraries as comma-separated string and transforms to array", () => {
+    const result = SourceConfigSchema.safeParse({
+      ...base,
+      "jdbc-options": { libraries: "MYLIB, DEVDATA, QGPL" },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data["jdbc-options"]?.libraries).toEqual([
+        "MYLIB",
+        "DEVDATA",
+        "QGPL",
+      ]);
+    }
+  });
+
+  it("1.3 – accepts a single library as string", () => {
+    const result = SourceConfigSchema.safeParse({
+      ...base,
+      "jdbc-options": { libraries: "MYLIB" },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data["jdbc-options"]?.libraries).toEqual(["MYLIB"]);
+    }
+  });
+
+  it("1.4 – jdbc-options is optional (omitting it succeeds)", () => {
+    const result = SourceConfigSchema.safeParse(base);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data["jdbc-options"]).toBeUndefined();
+    }
+  });
+
+  it("1.5 – rejects empty strings in libraries array", () => {
+    const result = SourceConfigSchema.safeParse({
+      ...base,
+      "jdbc-options": { libraries: ["MYLIB", ""] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("1.6 – libraries comma-separated string handles extra whitespace", () => {
+    const result = SourceConfigSchema.safeParse({
+      ...base,
+      "jdbc-options": { libraries: "  MYLIB ,  DEVDATA  ,  QGPL  " },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data["jdbc-options"]?.libraries).toEqual([
+        "MYLIB",
+        "DEVDATA",
+        "QGPL",
+      ]);
+    }
+  });
+
+  it("1.7 – filters empty entries from libraries comma-separated string", () => {
+    const result = SourceConfigSchema.safeParse({
+      ...base,
+      "jdbc-options": { libraries: "MYLIB,,DEVDATA," },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data["jdbc-options"]?.libraries).toEqual([
+        "MYLIB",
+        "DEVDATA",
+      ]);
+    }
+  });
+
+  it("1.8 – empty libraries string results in empty array", () => {
+    const result = SourceConfigSchema.safeParse({
+      ...base,
+      "jdbc-options": { libraries: "" },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data["jdbc-options"]?.libraries).toEqual([]);
+    }
+  });
+
+  it("1.9 – accepts non-libraries JDBC options (naming, date format)", () => {
+    const result = SourceConfigSchema.safeParse({
+      ...base,
+      "jdbc-options": { naming: "system", "date format": "iso" },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data["jdbc-options"]).toEqual({
+        naming: "system",
+        "date format": "iso",
+      });
+    }
+  });
+
+  it("1.10 – accepts libraries combined with other JDBC options", () => {
+    const result = SourceConfigSchema.safeParse({
+      ...base,
+      "jdbc-options": {
+        libraries: ["MYLIB", "DEVDATA"],
+        naming: "system",
+        "date format": "iso",
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data["jdbc-options"]?.libraries).toEqual([
+        "MYLIB",
+        "DEVDATA",
+      ]);
+      expect(result.data["jdbc-options"]).toMatchObject({
+        naming: "system",
+        "date format": "iso",
+      });
+    }
+  });
+
+  it("1.11 – empty jdbc-options object parses successfully", () => {
+    const result = SourceConfigSchema.safeParse({
+      ...base,
+      "jdbc-options": {},
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data["jdbc-options"]).toEqual({});
+    }
+  });
+
+  it("1.12 – passthrough: unknown keys (typos) pass validation", () => {
+    // Documents the intentional tradeoff of `.passthrough()`: typos like
+    // `librarys` silently flow through. Exhaustive enum would couple the
+    // schema to mapepire's 60+ JDBCOption keys and break on upstream additions.
+    const result = SourceConfigSchema.safeParse({
+      ...base,
+      "jdbc-options": { librarys: ["MYLIB"] },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // The typo is preserved in the parsed output (forwarded to mapepire as-is)
+      expect(
+        (result.data["jdbc-options"] as Record<string, unknown>).librarys,
+      ).toEqual(["MYLIB"]);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Group 2 – SqlToolsConfigSchema with jdbc-options in sources
+// ═══════════════════════════════════════════════════════════════════════════
+describe("SqlToolsConfigSchema – jdbc-options in YAML sources", () => {
+  it("2.1 – full YAML config with jdbc-options parses correctly", () => {
+    const result = SqlToolsConfigSchema.safeParse({
+      sources: {
+        "dev-system": {
+          host: "dev400.example.com",
+          user: "DEVUSER",
+          password: "devpass",
+          port: 8076,
+          "jdbc-options": {
+            libraries: ["DEVLIB", "DEVDATA", "QGPL"],
+          },
+        },
+      },
+      tools: {
+        get_status: {
+          source: "dev-system",
+          description: "Get system status",
+          statement: "SELECT * FROM QSYS2.SYSTEM_STATUS_INFO",
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(
+        result.data.sources!["dev-system"]["jdbc-options"]?.libraries,
+      ).toEqual(["DEVLIB", "DEVDATA", "QGPL"]);
+    }
+  });
+
+  it("2.2 – YAML config without jdbc-options still parses", () => {
+    const result = SqlToolsConfigSchema.safeParse({
+      sources: {
+        "prod-system": {
+          host: "prod400.example.com",
+          user: "PRODUSER",
+          password: "prodpass",
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Group 3 – DB2i_JDBC_OPTIONS env var parser
+// ═══════════════════════════════════════════════════════════════════════════
+describe("config.db2i – DB2i_JDBC_OPTIONS env var parser", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  function setCreds() {
+    process.env.DB2i_HOST = "testhost";
+    process.env.DB2i_USER = "testuser";
+    process.env.DB2i_PASS = "testpass";
+  }
+
+  it("3.1 – parses simple key=value pairs (naming, date format)", () => {
+    setCreds();
+    process.env.DB2i_JDBC_OPTIONS = "naming=system;date format=iso";
+
+    expect(config.db2i!.jdbcOptions).toEqual({
+      naming: "system",
+      "date format": "iso",
+    });
+  });
+
+  it("3.2 – parses libraries as comma-separated array within one value", () => {
+    setCreds();
+    process.env.DB2i_JDBC_OPTIONS = "libraries=A,B,C";
+
+    expect(config.db2i!.jdbcOptions).toEqual({
+      libraries: ["A", "B", "C"],
+    });
+  });
+
+  it("3.3 – combined options forward booleans as strings (no coercion)", () => {
+    setCreds();
+    process.env.DB2i_JDBC_OPTIONS =
+      "naming=system;libraries=A,B;full open=true";
+
+    const jdbcOptions = config.db2i!.jdbcOptions as Record<string, unknown>;
+    expect(jdbcOptions.naming).toBe("system");
+    expect(jdbcOptions.libraries).toEqual(["A", "B"]);
+    // "full open=true" stays as the string "true", NOT boolean true — the JDBC
+    // driver is string-based underneath; no bool coercion in the parser.
+    expect(jdbcOptions["full open"]).toBe("true");
+    expect(jdbcOptions["full open"]).not.toBe(true);
+  });
+
+  it("3.4 – trims whitespace around keys, values, and within libraries list", () => {
+    setCreds();
+    process.env.DB2i_JDBC_OPTIONS =
+      " naming = system ; libraries = A , B ";
+
+    expect(config.db2i!.jdbcOptions).toEqual({
+      naming: "system",
+      libraries: ["A", "B"],
+    });
+  });
+
+  it("3.5 – ignores empty segments (double semicolons, leading/trailing)", () => {
+    setCreds();
+    process.env.DB2i_JDBC_OPTIONS =
+      ";naming=system;;date format=iso;";
+
+    expect(config.db2i!.jdbcOptions).toEqual({
+      naming: "system",
+      "date format": "iso",
+    });
+  });
+
+  it("3.6 – throws on malformed pair (no `=`)", () => {
+    setCreds();
+    process.env.DB2i_JDBC_OPTIONS = "naming=system;broken";
+
+    expect(() => config.db2i).toThrow(/malformed pair/i);
+  });
+
+  it("3.7 – throws on empty key", () => {
+    setCreds();
+    process.env.DB2i_JDBC_OPTIONS = "=value;naming=system";
+
+    expect(() => config.db2i).toThrow(/empty key/i);
+  });
+
+  it("3.8 – omits jdbcOptions when env var is not set", () => {
+    setCreds();
+    delete process.env.DB2i_JDBC_OPTIONS;
+
+    const db2i = config.db2i;
+    expect(db2i).toBeDefined();
+    expect(db2i!.jdbcOptions).toBeUndefined();
+  });
+
+  it("3.9 – omits jdbcOptions when env var is empty string", () => {
+    setCreds();
+    process.env.DB2i_JDBC_OPTIONS = "";
+
+    expect(config.db2i!.jdbcOptions).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Group 4 – BaseConnectionPool passes JDBC opts to mapepire Pool
+// ═══════════════════════════════════════════════════════════════════════════
+describe("BaseConnectionPool – jdbcOptions JDBC wiring", () => {
+  let pool: TestConnectionPool;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetMocks();
+    config.poolTimeouts.queryTimeoutMs = 0;
+    config.poolTimeouts.idleTimeoutMs = 0;
+  });
+
+  afterEach(async () => {
+    await BaseConnectionPool.shutdownAll();
+    restoreConfig();
+    vi.useRealTimers();
+  });
+
+  it("4.1 – passes libraries in opts when jdbcOptions.libraries is configured", async () => {
+    pool = new TestConnectionPool();
+    const configWithLibs: PoolConnectionConfig = {
+      ...BASE_CONFIG,
+      jdbcOptions: { libraries: ["MYLIB", "DEVDATA", "QGPL"] },
+    };
+
+    await pool.testInitializePool("test-libs", configWithLibs, TEST_CONTEXT);
+
+    expect(MockPool).toHaveBeenCalledTimes(1);
+    const poolArgs = MockPool.mock.calls[0][0];
+    expect(poolArgs.opts).toBeDefined();
+    expect(poolArgs.opts.libraries).toEqual(["MYLIB", "DEVDATA", "QGPL"]);
+  });
+
+  it("4.2 – does not pass opts when jdbcOptions is undefined", async () => {
+    pool = new TestConnectionPool();
+    await pool.testInitializePool("test-no-libs", BASE_CONFIG, TEST_CONTEXT);
+
+    expect(MockPool).toHaveBeenCalledTimes(1);
+    const poolArgs = MockPool.mock.calls[0][0];
+    expect(poolArgs.opts).toBeUndefined();
+  });
+
+  it("4.3 – does not pass opts when jdbcOptions is empty object {}", async () => {
+    pool = new TestConnectionPool();
+    const configWithEmpty: PoolConnectionConfig = {
+      ...BASE_CONFIG,
+      jdbcOptions: {},
+    };
+
+    await pool.testInitializePool("test-empty", configWithEmpty, TEST_CONTEXT);
+
+    expect(MockPool).toHaveBeenCalledTimes(1);
+    const poolArgs = MockPool.mock.calls[0][0];
+    expect(poolArgs.opts).toBeUndefined();
+  });
+
+  it("4.4 – pool still initializes and executes queries with jdbc-options", async () => {
+    pool = new TestConnectionPool();
+    const configWithLibs: PoolConnectionConfig = {
+      ...BASE_CONFIG,
+      jdbcOptions: { libraries: ["MYLIB"] },
+    };
+
+    await pool.testInitializePool("test-query", configWithLibs, TEST_CONTEXT);
+
+    const result = await pool.testExecuteQuery("test-query", "SELECT 1");
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual([{ result: 1 }]);
+  });
+
+  it("4.5 – jdbcOptions preserved through pool re-initialization after timeout", async () => {
+    config.poolTimeouts.queryTimeoutMs = 1_000;
+    pool = new TestConnectionPool();
+    const configWithLibs: PoolConnectionConfig = {
+      ...BASE_CONFIG,
+      jdbcOptions: { libraries: ["MYLIB", "DEVDATA"] },
+    };
+
+    await pool.testInitializePool("test-reinit", configWithLibs, TEST_CONTEXT);
+
+    // First call: trigger timeout
+    mockPoolInstance.execute.mockReturnValueOnce(new Promise(() => {}));
+    const queryPromise = pool.testExecuteQuery("test-reinit", "SELECT SLOW()");
+    const assertion = expect(queryPromise).rejects.toThrow(/timed out/i);
+    await vi.advanceTimersByTimeAsync(1_001);
+    await assertion;
+
+    // Reset execute to succeed
+    mockPoolInstance.execute.mockResolvedValue(SUCCESSFUL_RESULT);
+
+    // Second call: should re-init with same jdbcOptions
+    await pool.testExecuteQuery("test-reinit", "SELECT 1");
+
+    expect(MockPool).toHaveBeenCalledTimes(2);
+    expect(MockPool.mock.calls[0][0].opts.libraries).toEqual([
+      "MYLIB",
+      "DEVDATA",
+    ]);
+    expect(MockPool.mock.calls[1][0].opts.libraries).toEqual([
+      "MYLIB",
+      "DEVDATA",
+    ]);
+  });
+
+  it("4.6 – creds, maxSize, startingSize are still passed correctly with jdbcOptions", async () => {
+    pool = new TestConnectionPool();
+    const configWithLibs: PoolConnectionConfig = {
+      ...BASE_CONFIG,
+      jdbcOptions: { libraries: ["LIB1"] },
+      maxSize: 20,
+      startingSize: 5,
+    };
+
+    await pool.testInitializePool("test-full", configWithLibs, TEST_CONTEXT);
+
+    const poolArgs = MockPool.mock.calls[0][0];
+    expect(poolArgs.creds.host).toBe("test-host");
+    expect(poolArgs.creds.user).toBe("testuser");
+    expect(poolArgs.maxSize).toBe(20);
+    expect(poolArgs.startingSize).toBe(5);
+    expect(poolArgs.opts.libraries).toEqual(["LIB1"]);
+  });
+
+  it("4.7 – passes non-libraries JDBC options (e.g., naming) to Pool opts", async () => {
+    pool = new TestConnectionPool();
+    const cfg: PoolConnectionConfig = {
+      ...BASE_CONFIG,
+      jdbcOptions: { naming: "system", "date format": "iso" },
+    };
+
+    await pool.testInitializePool("test-naming", cfg, TEST_CONTEXT);
+
+    const poolArgs = MockPool.mock.calls[0][0];
+    expect(poolArgs.opts).toEqual({
+      naming: "system",
+      "date format": "iso",
+    });
+  });
+
+  it("4.8 – passes combined libraries + other JDBC options to Pool opts", async () => {
+    pool = new TestConnectionPool();
+    const cfg: PoolConnectionConfig = {
+      ...BASE_CONFIG,
+      jdbcOptions: {
+        libraries: ["MYLIB"],
+        naming: "system",
+        "date format": "iso",
+      },
+    };
+
+    await pool.testInitializePool("test-combo", cfg, TEST_CONTEXT);
+
+    const poolArgs = MockPool.mock.calls[0][0];
+    expect(poolArgs.opts.libraries).toEqual(["MYLIB"]);
+    expect(poolArgs.opts.naming).toBe("system");
+    expect(poolArgs.opts["date format"]).toBe("iso");
+  });
+
+  it("4.9 – does NOT pass opts when jdbcOptions is empty object {} (duplicate of 4.3 for plan-table parity)", async () => {
+    pool = new TestConnectionPool();
+    const cfg: PoolConnectionConfig = {
+      ...BASE_CONFIG,
+      jdbcOptions: {},
+    };
+
+    await pool.testInitializePool("test-empty-2", cfg, TEST_CONTEXT);
+
+    const poolArgs = MockPool.mock.calls[0][0];
+    expect(poolArgs.opts).toBeUndefined();
+  });
+
+  it("4.10 – logs only libraries, not full jdbcOptions (no `key ring password`)", async () => {
+    const logSpy = vi.spyOn(logger, "info");
+    pool = new TestConnectionPool();
+    const cfg: PoolConnectionConfig = {
+      ...BASE_CONFIG,
+      jdbcOptions: {
+        libraries: ["MYLIB"],
+        "key ring password": "s3cret",
+        naming: "system",
+      } as PoolConnectionConfig["jdbcOptions"],
+    };
+
+    await pool.testInitializePool("test-log-redact", cfg, TEST_CONTEXT);
+
+    // Find the pool-init log call
+    const initCall = logSpy.mock.calls.find(
+      (c) =>
+        typeof c[1] === "string" &&
+        c[1].includes("Initializing connection pool"),
+    );
+    expect(initCall).toBeDefined();
+    const logPayload = JSON.stringify(initCall![0]);
+    expect(logPayload).toContain("libraries");
+    expect(logPayload).not.toContain("key ring password");
+    expect(logPayload).not.toContain("s3cret");
+    // Ensure non-sensitive non-libraries fields are also NOT logged (the log
+    // contract is "libraries only", not "libraries + safe-looking fields")
+    expect(logPayload).not.toContain("naming");
+
+    logSpy.mockRestore();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Group 5 – SourceManager jdbc-options wiring (YAML base, env override)
+// ═══════════════════════════════════════════════════════════════════════════
+describe("SourceManager – jdbc-options wiring", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetMocks();
+    config.poolTimeouts.queryTimeoutMs = 0;
+    config.poolTimeouts.idleTimeoutMs = 0;
+  });
+
+  afterEach(async () => {
+    await BaseConnectionPool.shutdownAll();
+    restoreConfig();
+    vi.useRealTimers();
+    process.env = { ...originalEnv };
+  });
+
+  it("5.1 – registerSource stores libraries in pool config from array", async () => {
+    const sm = new TestSourceManager();
+    await sm.registerSource("dev", {
+      host: "dev400",
+      user: "devuser",
+      password: "devpass",
+      port: 8076,
+      "jdbc-options": { libraries: ["DEVLIB", "DEVDATA"] },
+    });
+
+    const poolState = sm.getPoolsMap().get("dev");
+    expect(poolState).toBeDefined();
+    expect(poolState!.config.jdbcOptions?.libraries).toEqual([
+      "DEVLIB",
+      "DEVDATA",
+    ]);
+  });
+
+  it("5.2 – registerSource works without jdbc-options", async () => {
+    const sm = new TestSourceManager();
+    await sm.registerSource("prod", {
+      host: "prod400",
+      user: "produser",
+      password: "prodpass",
+      port: 8076,
+    });
+
+    const poolState = sm.getPoolsMap().get("prod");
+    expect(poolState).toBeDefined();
+    expect(poolState!.config.jdbcOptions).toBeUndefined();
+  });
+
+  it("5.3 – different sources can have different jdbc-options", async () => {
+    const sm = new TestSourceManager();
+    await sm.registerSource("dev", {
+      host: "dev400",
+      user: "u",
+      password: "p",
+      "jdbc-options": { libraries: ["DEVLIB"] },
+    });
+    await sm.registerSource("staging", {
+      host: "stg400",
+      user: "u",
+      password: "p",
+      "jdbc-options": { libraries: ["STGLIB", "STGDATA"] },
+    });
+    await sm.registerSource("prod", {
+      host: "prod400",
+      user: "u",
+      password: "p",
+    });
+
+    expect(
+      sm.getPoolsMap().get("dev")!.config.jdbcOptions?.libraries,
+    ).toEqual(["DEVLIB"]);
+    expect(
+      sm.getPoolsMap().get("staging")!.config.jdbcOptions?.libraries,
+    ).toEqual(["STGLIB", "STGDATA"]);
+    expect(sm.getPoolsMap().get("prod")!.config.jdbcOptions).toBeUndefined();
+  });
+
+  it("5.4 – jdbc-options flows through to mapepire Pool on first query", async () => {
+    const sm = new TestSourceManager();
+    await sm.registerSource("dev", {
+      host: "dev400",
+      user: "devuser",
+      password: "devpass",
+      "jdbc-options": { libraries: ["DEVLIB", "DEVDATA"] },
+    });
+
+    await sm.executeQuery("dev", "SELECT 1 FROM SYSIBM.SYSDUMMY1");
+
+    expect(MockPool).toHaveBeenCalledTimes(1);
+    const poolArgs = MockPool.mock.calls[0][0];
+    expect(poolArgs.opts).toBeDefined();
+    expect(poolArgs.opts.libraries).toEqual(["DEVLIB", "DEVDATA"]);
+  });
+
+  it("5.5 – source without jdbc-options does not pass opts to Pool", async () => {
+    const sm = new TestSourceManager();
+    await sm.registerSource("plain", {
+      host: "plain400",
+      user: "user",
+      password: "pass",
+    });
+
+    await sm.executeQuery("plain", "SELECT 1 FROM SYSIBM.SYSDUMMY1");
+
+    expect(MockPool).toHaveBeenCalledTimes(1);
+    const poolArgs = MockPool.mock.calls[0][0];
+    expect(poolArgs.opts).toBeUndefined();
+  });
+
+  it("5.6 – non-libraries JDBC options flow through on first query", async () => {
+    const sm = new TestSourceManager();
+    await sm.registerSource("dev", {
+      host: "dev400",
+      user: "u",
+      password: "p",
+      "jdbc-options": { naming: "system", "date format": "iso" },
+    });
+
+    await sm.executeQuery("dev", "SELECT 1 FROM SYSIBM.SYSDUMMY1");
+
+    const poolArgs = MockPool.mock.calls[0][0];
+    expect(poolArgs.opts).toEqual({
+      naming: "system",
+      "date format": "iso",
+    });
+  });
+
+  it("5.7 – env jdbcOptions overrides YAML jdbc-options (merge, env wins)", async () => {
+    // Env sets naming=system and libraries=ENVLIB; YAML sets naming=sql and libraries=YAMLLIB.
+    // Env should win on both keys.
+    process.env.DB2i_HOST = "envhost";
+    process.env.DB2i_USER = "envuser";
+    process.env.DB2i_PASS = "envpass";
+    process.env.DB2i_JDBC_OPTIONS = "naming=system;libraries=ENVLIB";
+
+    const sm = new TestSourceManager();
+    await sm.registerSource("dev", {
+      host: "dev400",
+      user: "u",
+      password: "p",
+      "jdbc-options": {
+        naming: "sql",
+        libraries: ["YAMLLIB"],
+        "date format": "iso",
+      },
+    });
+
+    const poolState = sm.getPoolsMap().get("dev");
+    expect(poolState!.config.jdbcOptions).toEqual({
+      naming: "system",
+      libraries: ["ENVLIB"],
+      "date format": "iso", // from YAML, not overridden by env
+    });
+  });
+
+  it("5.8 – YAML jdbc-options alone (no env) reaches Pool unchanged", async () => {
+    delete process.env.DB2i_JDBC_OPTIONS;
+
+    const sm = new TestSourceManager();
+    await sm.registerSource("dev", {
+      host: "dev400",
+      user: "u",
+      password: "p",
+      "jdbc-options": {
+        libraries: ["YAMLLIB"],
+        naming: "sql",
+      },
+    });
+
+    await sm.executeQuery("dev", "SELECT 1 FROM SYSIBM.SYSDUMMY1");
+
+    const poolArgs = MockPool.mock.calls[0][0];
+    expect(poolArgs.opts).toEqual({
+      libraries: ["YAMLLIB"],
+      naming: "sql",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the single-purpose `library-list` YAML field and `DB2i_LIBRARY_LIST` env var proposed in #138 with a general-purpose surface for any [mapepire `JDBCOption`](https://javadoc.io/static/net.sf.jt400/jt400/21.0.0/com/ibm/as400/access/doc-files/JDBCProperties.html) — libraries, naming convention, date format, time format, and the other 50+ JDBC driver properties.

**Relationship to #138**: This PR supersedes #138 and expands on #133 by generalizing the underlying need (letting operators configure IBM i JDBC behavior per source and per deployment). #138 correctly identified the gap — library list support — and this PR addresses it alongside every other JDBCOption in a single unified mechanism. Full credit to @vijaygovindaraja for raising original PR.

## Motivation

`library-list` as implemented in #138 hard-codes one JDBCOption by name. Mapepire's `JDBCOptions` interface has 60+ properties; the next time someone needs `naming=system` or `date format=iso`, the pattern would have to be duplicated.

A single `jdbc-options` passthrough object eliminates both problems: every JDBCOption is available without code changes, and the `opts` payload is built from one merged source.

## What changed

### YAML (`sources[].jdbc-options`)

```yaml
sources:
  ibmi-dev:
    host: ${DB2i_HOST}
    user: ${DB2i_USER}
    password: ${DB2i_PASS}
    jdbc-options:
      libraries: [MYLIB, DEVDATA, QGPL]
      naming: system
      date format: iso
```

A passthrough object that forwards every key to the mapepire Pool `opts`. `libraries` keeps the string/array dual-accept behavior from #138 (`libraries: \"MYLIB, DEVDATA\"` still parses into an array).

### Env var (`DB2i_JDBC_OPTIONS`)

Semicolon-separated `key=value` pairs modeled on DB2 JDBC URL syntax:

```bash
DB2i_JDBC_OPTIONS='naming=system;date format=iso;libraries=MYLIB,DEVDATA'
```

- `;` separates outer pairs; empty segments are ignored
- First `=` splits each pair (values may contain `=`)
- Keys with spaces (`date format`, `key ring password`) work unquoted
- `libraries` is comma-split within its pair; all other values forwarded as strings
- Malformed pairs throw a clear error at startup

### Precedence

`DB2i_JDBC_OPTIONS` is shallow-merged over each YAML source's `jdbc-options`. Env values win on per-key collisions; YAML-only keys are preserved. This lets operators enforce fleet-wide JDBC config without editing per-deployment YAML files.

### Log redaction (new)

Pool-init log lines emit only the `libraries` field. Other JDBCOption values — including sensitive ones like `key ring password`, `proxy server`, and `trace` — are intentionally excluded from every log level. E2E verified against real driver output: a grep of `~/.ibmi-mcp-server/logs/` found zero matches for \`date format\`, \`iso\`, \`usa\`, or \`eur\` after running queries with each set.

## Testing

- **Unit**: 41 tests in \`jdbcOptions.test.ts\` (27 updated from the original library-list tests + 14 new) covering schema passthrough/typo tolerance, env parser edge cases (whitespace, empty segments, malformed pairs, string-only coercion), log redaction, and env-over-YAML merge.
- **E2E**: Validated against a real IBM i — `date format=iso|usa|eur` all returned correctly formatted dates from `SELECT CHAR(CURRENT_DATE)`. Log redaction verified on live driver output.
- **Regression**: Full suite (770 tests across 53 files) green on this branch.

## Breaking changes

This supersedes the unreleased #138, so no user-facing break. If you're already running a local build off #138's branch:

| Before (#138) | After (this PR) |
|---|---|
| `library-list: [MYLIB, FOO]` | `jdbc-options: { libraries: [MYLIB, FOO] }` |
| `DB2i_LIBRARY_LIST=MYLIB,FOO` | `DB2i_JDBC_OPTIONS='libraries=MYLIB,FOO'` |

## Files

| Area | Files |
|---|---|
| Feature | \`server/src/config/index.ts\`, \`server/src/ibmi-mcp-server/schemas/config.ts\`, \`server/src/ibmi-mcp-server/services/{baseConnectionPool,connectionPool,sourceManager}.ts\`, \`server/.env.example\` |
| Tests | \`server/tests/ibmi-mcp-server/services/jdbcOptions.test.ts\` |
| Docs | \`docs/configuration.mdx\`, \`docs/sql-tools/sources.mdx\` |

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 770/770 pass
- [x] \`npm run build\` clean
- [x] E2E on real IBM i: \`date format=iso|usa|eur\` all return correct formats
- [x] Log redaction: grep of real driver logs finds no leaked JDBC values
- [x] Mintlify dev preview: all new doc sections render correctly (tables, tabs, callouts, anchors)