### PR TITLE
feat(yaml): add rowsToFetch and fetchAllRows per-tool config

### DIFF
--- a/packages/cli/src/commands/tool.ts
+++ b/packages/cli/src/commands/tool.ts
@@ -300,12 +300,21 @@ async function executeTool(
       );
     }
 
-    // Execute the query
-    const result = await IBMiConnectionPool.executeQuery(
-      processedSql,
-      bindingParams,
-      ctx,
-    );
+    // Execute the query, honoring YAML-declared fetch controls.
+    // fetchAllRows wins over rowsToFetch (per the locked design decision
+    // for issue #139).
+    const result = tool.fetchAllRows
+      ? await IBMiConnectionPool.executeQueryWithPagination(
+          processedSql,
+          bindingParams,
+          ctx,
+        )
+      : await IBMiConnectionPool.executeQuery(
+          processedSql,
+          bindingParams,
+          ctx,
+          tool.rowsToFetch,
+        );
 
     const elapsedMs = Date.now() - startTime;
     const data = (result.data ?? []) as Record<string, unknown>[];

--- a/packages/cli/src/utils/yaml-loader.ts
+++ b/packages/cli/src/utils/yaml-loader.ts
@@ -42,6 +42,8 @@ export interface YamlToolConfig {
   responseFormat?: string;
   tableFormat?: string;
   maxDisplayRows?: number;
+  rowsToFetch?: number;
+  fetchAllRows?: boolean;
   enabled?: boolean;
   annotations?: Record<string, unknown>;
 }
@@ -111,6 +113,8 @@ function normalizeTools(
       responseFormat: tool["responseFormat"] as string | undefined,
       tableFormat: tool["tableFormat"] as string | undefined,
       maxDisplayRows: tool["maxDisplayRows"] as number | undefined,
+      rowsToFetch: tool["rowsToFetch"] as number | undefined,
+      fetchAllRows: tool["fetchAllRows"] as boolean | undefined,
       enabled: tool["enabled"] as boolean | undefined,
       annotations: tool["annotations"] as Record<string, unknown> | undefined,
     };

--- a/packages/server/src/ibmi-mcp-server/schemas/config.ts
+++ b/packages/server/src/ibmi-mcp-server/schemas/config.ts
@@ -211,6 +211,20 @@ export const SqlToolConfigSchema = z
       .describe(
         "Maximum number of rows to display in result tables (default: 100). Rows beyond this limit will show a truncation message",
       ),
+    rowsToFetch: z
+      .number()
+      .int()
+      .min(1, "rowsToFetch must be at least 1")
+      .optional()
+      .describe(
+        "Maximum rows to fetch from the database per call (default: mapepire's 100). Controls the actual query fetch, not display truncation. Ignored if fetchAllRows is true.",
+      ),
+    fetchAllRows: z
+      .boolean()
+      .optional()
+      .describe(
+        "When true, fetches all rows using paginated fetches (bounded by internal safety cap ~30k). Takes precedence over rowsToFetch. Use sparingly — large result sets bloat LLM context.",
+      ),
 
     // Legacy deprecated fields (for backward compatibility)
     readOnlyHint: z

--- a/packages/server/src/ibmi-mcp-server/schemas/json/sql-tools-config.json
+++ b/packages/server/src/ibmi-mcp-server/schemas/json/sql-tools-config.json
@@ -303,6 +303,15 @@
                 "default": 100,
                 "description": "Maximum number of rows to display in result tables (default: 100). Rows beyond this limit will show a truncation message"
               },
+              "rowsToFetch": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Maximum rows to fetch from the database per call (default: mapepire's 100). Controls actual query fetch, not display. Ignored if fetchAllRows is true."
+              },
+              "fetchAllRows": {
+                "type": "boolean",
+                "description": "When true, fetches all rows using paginated fetches (bounded by internal safety cap ~30k). Takes precedence over rowsToFetch."
+              },
               "readOnlyHint": {
                 "type": "boolean",
                 "description": "@deprecated Use annotations.readOnlyHint instead"

--- a/packages/server/src/ibmi-mcp-server/services/authenticatedPoolManager.ts
+++ b/packages/server/src/ibmi-mcp-server/services/authenticatedPoolManager.ts
@@ -184,6 +184,7 @@ export class AuthenticatedPoolManager extends BaseConnectionPool<string> {
     params?: BindingValue[],
     context?: RequestContext,
     securityConfig?: SqlToolSecurityConfig,
+    rowsToFetch?: number,
   ): Promise<QueryResult<T>> {
     const operationContext =
       context ||
@@ -222,6 +223,7 @@ export class AuthenticatedPoolManager extends BaseConnectionPool<string> {
           params,
           operationContext,
           securityConfig,
+          rowsToFetch,
         );
 
         logger.debug(
@@ -238,6 +240,61 @@ export class AuthenticatedPoolManager extends BaseConnectionPool<string> {
       },
       {
         operation: "executeAuthenticatedQuery",
+        context: operationContext,
+        errorCode: JsonRpcErrorCode.DatabaseError,
+      },
+    );
+  }
+
+  /**
+   * Execute a query with automatic pagination using an authenticated pool.
+   * Fetches all available rows via repeated fetchMore calls (bounded by the
+   * base pool's internal safety cap, ~30k rows).
+   * @param token - Authentication token
+   * @param query - SQL query to execute
+   * @param params - Query parameters
+   * @param context - Request context for logging
+   * @param securityConfig - Optional security configuration
+   */
+  async executeQueryWithPagination(
+    token: string,
+    query: string,
+    params?: BindingValue[],
+    context?: RequestContext,
+    fetchSize: number = 300,
+    securityConfig?: SqlToolSecurityConfig,
+  ) {
+    const operationContext =
+      context ||
+      requestContextService.createRequestContext({
+        operation: "executeAuthenticatedQueryWithPagination",
+        token: token.substring(0, 10) + "...",
+      });
+
+    return ErrorHandler.tryCatch(
+      async () => {
+        const isValid = await this.validateTokenAndPool(
+          token,
+          operationContext,
+        );
+        if (!isValid) {
+          throw new McpError(
+            JsonRpcErrorCode.Unauthorized,
+            "Invalid or expired authentication token",
+          );
+        }
+
+        return super.executeQueryWithPagination(
+          token,
+          query,
+          params,
+          operationContext,
+          fetchSize,
+          securityConfig,
+        );
+      },
+      {
+        operation: "executeAuthenticatedQueryWithPagination",
         context: operationContext,
         errorCode: JsonRpcErrorCode.DatabaseError,
       },

--- a/packages/server/src/ibmi-mcp-server/services/baseConnectionPool.ts
+++ b/packages/server/src/ibmi-mcp-server/services/baseConnectionPool.ts
@@ -5,7 +5,12 @@
  * @module src/services/baseConnectionPool
  */
 
-import pkg, { BindingValue, QueryResult, DaemonServer } from "@ibm/mapepire-js";
+import pkg, {
+  BindingValue,
+  QueryResult,
+  DaemonServer,
+  QueryMetaData,
+} from "@ibm/mapepire-js";
 import type { JDBCOptions } from "@ibm/mapepire-js";
 const { Pool, getRootCertificate } = pkg;
 import { ErrorHandler, logger } from "@/utils/internal/index.js";
@@ -397,6 +402,7 @@ export abstract class BaseConnectionPool<TId extends string | symbol = string> {
     params?: BindingValue[],
     context?: RequestContext,
     securityConfig?: SqlToolSecurityConfig,
+    rowsToFetch?: number,
   ): Promise<QueryResult<T>> {
     const operationContext =
       context ||
@@ -447,9 +453,20 @@ export abstract class BaseConnectionPool<TId extends string | symbol = string> {
             queryLength: query.length,
             hasParameters: !!params && params.length > 0,
             paramCount: params?.length || 0,
+            rowsToFetch,
           },
           `Executing SQL query on pool: ${String(poolId)}`,
         );
+
+        if (rowsToFetch !== undefined && rowsToFetch > 10_000) {
+          logger.warning(
+            {
+              ...operationContext,
+              rowsToFetch,
+            },
+            `Large rowsToFetch requested (${rowsToFetch}). Large result sets can bloat LLM context and consume memory. Consider using pagination via SQL OFFSET/FETCH FIRST instead.`,
+          );
+        }
 
         // Validate parameter types for mapepire compatibility
         if (params && params.length > 0) {
@@ -488,13 +505,38 @@ export abstract class BaseConnectionPool<TId extends string | symbol = string> {
           );
         }
 
-        const result = await this.executeWithTimeout<QueryResult<T>>(
-          poolId,
-          poolState.pool.execute(query, {
-            parameters: params,
-          }) as Promise<QueryResult<T>>,
-          operationContext,
-        );
+        // Use pool.query().execute(rowsToFetch) so per-call row limits are honored.
+        // mapepire's pool.execute() QueryOptions doesn't accept rowsToFetch; the
+        // Query.execute(n) path does. close() releases the job back to the pool.
+        const queryObj = poolState.pool.query(query, {
+          parameters: params,
+        });
+        const executionPromise = (
+          rowsToFetch !== undefined
+            ? queryObj.execute(rowsToFetch)
+            : queryObj.execute()
+        ) as Promise<QueryResult<T>>;
+        let result: QueryResult<T>;
+        try {
+          result = await this.executeWithTimeout<QueryResult<T>>(
+            poolId,
+            executionPromise,
+            operationContext,
+          );
+        } finally {
+          await queryObj.close().catch((closeErr: unknown) => {
+            logger.warning(
+              {
+                ...operationContext,
+                error:
+                  closeErr instanceof Error
+                    ? closeErr.message
+                    : String(closeErr),
+              },
+              "Failed to close query object after execution",
+            );
+          });
+        }
 
         logger.debug(
           {
@@ -542,6 +584,7 @@ export abstract class BaseConnectionPool<TId extends string | symbol = string> {
     success: boolean;
     sql_rc?: unknown;
     execution_time?: number;
+    metadata?: QueryMetaData;
   }> {
     const operationContext =
       context ||
@@ -600,6 +643,9 @@ export abstract class BaseConnectionPool<TId extends string | symbol = string> {
           queryObj.execute(),
           operationContext,
         );
+        // Capture metadata from the first result — subsequent fetchMore calls
+        // don't re-send column descriptors, so SQL tools need this snapshot.
+        const initialMetadata = result.metadata;
         const allData: unknown[] = [];
 
         if (result.success && result.data) {
@@ -651,6 +697,7 @@ export abstract class BaseConnectionPool<TId extends string | symbol = string> {
           success: result.success,
           sql_rc: result.sql_rc,
           execution_time: result.execution_time,
+          metadata: initialMetadata,
         };
       },
       {

--- a/packages/server/src/ibmi-mcp-server/services/connectionPool.ts
+++ b/packages/server/src/ibmi-mcp-server/services/connectionPool.ts
@@ -6,7 +6,7 @@
  * @module src/services/mapepire/connectionPool
  */
 
-import { BindingValue, QueryResult } from "@ibm/mapepire-js";
+import { BindingValue, QueryResult, QueryMetaData } from "@ibm/mapepire-js";
 import { config } from "@/config/index.js";
 import { logger } from "@/utils/internal/logger.js";
 import { ErrorHandler } from "@/utils/internal/errorHandler.js";
@@ -121,6 +121,7 @@ export class IBMiConnectionPool extends BaseConnectionPool<
     success: boolean;
     sql_rc?: unknown;
     execution_time?: number;
+    metadata?: QueryMetaData;
   }> {
     const operationContext =
       context ||
@@ -147,6 +148,7 @@ export class IBMiConnectionPool extends BaseConnectionPool<
     query: string,
     params?: BindingValue[],
     context?: RequestContext,
+    rowsToFetch?: number,
   ): Promise<QueryResult<unknown>> {
     const operationContext =
       context ||
@@ -161,6 +163,8 @@ export class IBMiConnectionPool extends BaseConnectionPool<
       query,
       params,
       operationContext,
+      undefined,
+      rowsToFetch,
     );
   }
 

--- a/packages/server/src/ibmi-mcp-server/services/sourceManager.ts
+++ b/packages/server/src/ibmi-mcp-server/services/sourceManager.ts
@@ -147,12 +147,42 @@ export class SourceManager extends BaseConnectionPool<string> {
     params?: BindingValue[],
     context?: RequestContext,
     securityConfig?: SqlToolSecurityConfig,
+    rowsToFetch?: number,
   ): Promise<QueryResult<T>> {
     return super.executeQuery<T>(
       sourceName,
       query,
       params,
       context,
+      securityConfig,
+      rowsToFetch,
+    );
+  }
+
+  /**
+   * Execute a SQL query with automatic pagination on a specific source
+   * Fetches all available rows via repeated fetchMore calls (bounded by
+   * the base pool's internal safety cap, ~30k rows).
+   * @param sourceName - Name of the source to query
+   * @param query - SQL query string
+   * @param params - Query parameters
+   * @param context - Request context for logging
+   * @param securityConfig - Optional security configuration
+   */
+  async executeQueryWithPagination(
+    sourceName: string,
+    query: string,
+    params?: BindingValue[],
+    context?: RequestContext,
+    fetchSize: number = 300,
+    securityConfig?: SqlToolSecurityConfig,
+  ) {
+    return super.executeQueryWithPagination(
+      sourceName,
+      query,
+      params,
+      context,
+      fetchSize,
       securityConfig,
     );
   }

--- a/packages/server/src/ibmi-mcp-server/utils/config/toolConfigBuilder.ts
+++ b/packages/server/src/ibmi-mcp-server/utils/config/toolConfigBuilder.ts
@@ -415,6 +415,8 @@ export class ToolConfigBuilder {
             config.parameters || [],
             executionContext,
             config.security,
+            config.rowsToFetch,
+            config.fetchAllRows,
           );
 
           const simplifiedColumns = (result.columns ?? []).map(

--- a/packages/server/src/ibmi-mcp-server/utils/config/toolFactory.ts
+++ b/packages/server/src/ibmi-mcp-server/utils/config/toolFactory.ts
@@ -64,6 +64,8 @@ export class SQLToolFactory {
     parameterDefinitions: SqlToolParameter[] = [],
     context?: RequestContext,
     securityConfig?: SqlToolSecurityConfig,
+    rowsToFetch?: number,
+    fetchAllRows?: boolean,
   ): Promise<SqlToolExecutionResult> {
     const operationContext =
       context ||
@@ -197,6 +199,8 @@ export class SQLToolFactory {
           sourceName,
           operationContext,
           securityConfig,
+          rowsToFetch,
+          fetchAllRows,
         );
 
         const executionTime = Date.now() - startTime;
@@ -268,9 +272,58 @@ export class SQLToolFactory {
     sourceName: string,
     context: RequestContext,
     securityConfig?: SqlToolSecurityConfig,
+    rowsToFetch?: number,
+    fetchAllRows?: boolean,
   ): Promise<QueryResult<T>> {
     // Check for IBM i authentication context
     const authInfo = authContext.getStore()?.authInfo;
+
+    // fetchAllRows wins over rowsToFetch. Routes through the
+    // executeQueryWithPagination path (mapepire pool.query().fetchMore loop).
+    if (fetchAllRows) {
+      logger.debug(
+        {
+          ...context,
+          sourceName,
+          routingMode: authInfo?.ibmiToken ? "authenticated" : "environment",
+          fetchMode: "paginated-all-rows",
+        },
+        "Executing SQL with fetchAllRows via pagination path",
+      );
+
+      const paginated = authInfo?.ibmiToken
+        ? await AuthenticatedPoolManager.getInstance().executeQueryWithPagination(
+            authInfo.ibmiToken,
+            sql,
+            parameters,
+            context,
+            undefined,
+            securityConfig,
+          )
+        : await this.sourceManager.executeQueryWithPagination(
+            sourceName,
+            sql,
+            parameters,
+            context,
+            undefined,
+            securityConfig,
+          );
+
+      // Adapt the paginated shape to QueryResult<T> so downstream
+      // executeStatementWithParameters can read .data and .metadata uniformly.
+      return {
+        success: paginated.success,
+        data: paginated.data as T[],
+        metadata: paginated.metadata ?? { columns: [] },
+        sql_rc: paginated.sql_rc as number,
+        execution_time: paginated.execution_time ?? 0,
+        is_done: true,
+        has_results: paginated.data.length > 0,
+        update_count: 0,
+        id: "",
+        sql_state: "",
+      } as QueryResult<T>;
+    }
 
     if (authInfo?.ibmiToken) {
       // Use authenticated pool manager when IBM i token is present
@@ -291,6 +344,7 @@ export class SQLToolFactory {
         parameters,
         context,
         securityConfig,
+        rowsToFetch,
       );
     } else {
       // Fall back to regular source manager (environment credentials)
@@ -299,10 +353,24 @@ export class SQLToolFactory {
           ...context,
           sourceName,
           routingMode: "environment",
+          rowsToFetch,
         },
         "Executing SQL via source manager",
       );
 
+      // Preserve the existing conditional call shape so downstream tests
+      // that assert exact arity keep passing. rowsToFetch/securityConfig are
+      // optional trailing args in sourceManager.executeQuery and safe to omit.
+      if (rowsToFetch !== undefined) {
+        return this.sourceManager.executeQuery<T>(
+          sourceName,
+          sql,
+          parameters,
+          context,
+          securityConfig,
+          rowsToFetch,
+        );
+      }
       return securityConfig
         ? this.sourceManager.executeQuery<T>(
             sourceName,

--- a/packages/server/tests/ibmi-mcp-server/services/baseConnectionPool.test.ts
+++ b/packages/server/tests/ibmi-mcp-server/services/baseConnectionPool.test.ts
@@ -9,19 +9,29 @@ import type { PoolConnectionConfig } from "../../../src/ibmi-mcp-server/services
 // ---------------------------------------------------------------------------
 // Hoisted mock state – vi.hoisted runs before vi.mock factories
 // ---------------------------------------------------------------------------
-const { mockPoolInstance, MockPool, mockGetRootCert } = vi.hoisted(() => {
-  const mockPoolInstance = {
-    init: vi.fn(),
-    execute: vi.fn(),
-    end: vi.fn(),
-    query: vi.fn(),
-  };
-  return {
-    mockPoolInstance,
-    MockPool: vi.fn(() => mockPoolInstance),
-    mockGetRootCert: vi.fn().mockResolvedValue("cert"),
-  };
-});
+const { mockPoolInstance, mockQueryInstance, MockPool, mockGetRootCert } =
+  vi.hoisted(() => {
+    // executeQuery now routes through pool.query().execute().close(), so the
+    // query object is the primary mock surface. executeQueryWithPagination
+    // also uses fetchMore(). Defaults are set in resetMocks().
+    const mockQueryInstance = {
+      execute: vi.fn(),
+      fetchMore: vi.fn(),
+      close: vi.fn(),
+    };
+    const mockPoolInstance = {
+      init: vi.fn(),
+      execute: vi.fn(),
+      end: vi.fn(),
+      query: vi.fn(() => mockQueryInstance),
+    };
+    return {
+      mockPoolInstance,
+      mockQueryInstance,
+      MockPool: vi.fn(() => mockPoolInstance),
+      mockGetRootCert: vi.fn().mockResolvedValue("cert"),
+    };
+  });
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -129,7 +139,18 @@ function resetMocks() {
   mockPoolInstance.init.mockReset().mockResolvedValue(undefined);
   mockPoolInstance.execute.mockReset().mockResolvedValue(SUCCESSFUL_RESULT);
   mockPoolInstance.end.mockReset().mockResolvedValue(undefined);
-  mockPoolInstance.query.mockReset();
+  // executeQuery uses pool.query().execute().close(); the pagination path
+  // uses pool.query().execute() + fetchMore() + close(). Reset and re-wire
+  // the query factory each run so mockImplementation in one test doesn't
+  // leak into the next.
+  mockPoolInstance.query
+    .mockReset()
+    .mockImplementation(() => mockQueryInstance);
+  mockQueryInstance.execute.mockReset().mockResolvedValue(SUCCESSFUL_RESULT);
+  mockQueryInstance.fetchMore
+    .mockReset()
+    .mockResolvedValue({ ...SUCCESSFUL_RESULT, is_done: true, data: [] });
+  mockQueryInstance.close.mockReset().mockResolvedValue(undefined);
   mockGetRootCert.mockClear();
 }
 
@@ -174,7 +195,7 @@ describe("BaseConnectionPool – Query Timeout", () => {
 
   it("1.2 – throws with 'timed out' when query exceeds timeout", async () => {
     // execute never resolves → timeout will fire
-    mockPoolInstance.execute.mockReturnValue(new Promise(() => {}));
+    mockQueryInstance.execute.mockReturnValue(new Promise(() => {}));
 
     const queryPromise = pool.testExecuteQuery("test", "SELECT SLOW()");
     // Attach assertion BEFORE advancing timers to prevent unhandled rejection
@@ -204,7 +225,7 @@ describe("BaseConnectionPool – Query Timeout", () => {
   });
 
   it("1.4 – non-timeout errors propagate with original message", async () => {
-    mockPoolInstance.execute.mockRejectedValue(
+    mockQueryInstance.execute.mockRejectedValue(
       new Error("SQLSTATE=42S02 Table not found"),
     );
 
@@ -227,7 +248,7 @@ describe("BaseConnectionPool – Query Timeout", () => {
 
   it("1.6 – pool re-initializes transparently after timeout closure", async () => {
     // First call: hangs → triggers timeout
-    mockPoolInstance.execute.mockReturnValueOnce(new Promise(() => {}));
+    mockQueryInstance.execute.mockReturnValueOnce(new Promise(() => {}));
 
     const firstCall = pool.testExecuteQuery("test", "SELECT SLOW()");
     const assertion = expect(firstCall).rejects.toThrow(/timed out/i);
@@ -235,7 +256,7 @@ describe("BaseConnectionPool – Query Timeout", () => {
     await assertion;
 
     // Reset execute to succeed for the next call
-    mockPoolInstance.execute.mockResolvedValue(SUCCESSFUL_RESULT);
+    mockQueryInstance.execute.mockResolvedValue(SUCCESSFUL_RESULT);
 
     // Second call should trigger re-init and succeed
     const secondResult = await pool.testExecuteQuery("test", "SELECT 1");
@@ -559,5 +580,72 @@ describe("SourceManager – getHealthSummary", () => {
     const sm = new TestSourceManager();
     const summary = sm.getHealthSummary();
     expect(summary).toEqual({});
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Group 5 – rowsToFetch threading (issue #139)
+// ═══════════════════════════════════════════════════════════════════════════
+describe("BaseConnectionPool – rowsToFetch threading", () => {
+  let pool: TestConnectionPool;
+
+  beforeEach(async () => {
+    resetMocks();
+    config.poolTimeouts.idleTimeoutMs = 0;
+    pool = new TestConnectionPool();
+    await pool.testInitializePool("test", TEST_CONFIG, TEST_CONTEXT);
+  });
+
+  afterEach(async () => {
+    await BaseConnectionPool.shutdownAll();
+    restoreConfig();
+  });
+
+  it("5.1 – omits rowsToFetch arg when not provided (mapepire default 100 applies)", async () => {
+    await pool.testExecuteQuery("test", "SELECT 1");
+
+    // pool.query() called with statement + parameters
+    expect(mockPoolInstance.query).toHaveBeenCalledWith("SELECT 1", {
+      parameters: undefined,
+    });
+    // execute() called without rowsToFetch so mapepire uses its default
+    expect(mockQueryInstance.execute).toHaveBeenCalledWith();
+    // close() always called to release the job
+    expect(mockQueryInstance.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("5.2 – forwards rowsToFetch to Query.execute(n)", async () => {
+    // Use the protected method through a typed subclass cast
+    const protectedPool = pool as unknown as {
+      executeQuery: (
+        poolId: string,
+        query: string,
+        params?: unknown[],
+        context?: Record<string, unknown>,
+        securityConfig?: unknown,
+        rowsToFetch?: number,
+      ) => Promise<unknown>;
+    };
+
+    await protectedPool.executeQuery(
+      "test",
+      "SELECT 1",
+      undefined,
+      TEST_CONTEXT,
+      undefined,
+      500,
+    );
+
+    expect(mockQueryInstance.execute).toHaveBeenCalledWith(500);
+    expect(mockQueryInstance.close).toHaveBeenCalled();
+  });
+
+  it("5.3 – close() still called when execute() rejects", async () => {
+    mockQueryInstance.execute.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(pool.testExecuteQuery("test", "SELECT 1")).rejects.toThrow(
+      /boom/,
+    );
+    expect(mockQueryInstance.close).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/server/tests/ibmi-mcp-server/services/jdbcOptions.test.ts
+++ b/packages/server/tests/ibmi-mcp-server/services/jdbcOptions.test.ts
@@ -11,19 +11,28 @@ import type { PoolConnectionConfig } from "../../../src/ibmi-mcp-server/services
 // ---------------------------------------------------------------------------
 // Hoisted mock state – vi.hoisted runs before vi.mock factories
 // ---------------------------------------------------------------------------
-const { mockPoolInstance, MockPool, mockGetRootCert } = vi.hoisted(() => {
-  const mockPoolInstance = {
-    init: vi.fn(),
-    execute: vi.fn(),
-    end: vi.fn(),
-    query: vi.fn(),
-  };
-  return {
-    mockPoolInstance,
-    MockPool: vi.fn(() => mockPoolInstance),
-    mockGetRootCert: vi.fn().mockResolvedValue("cert"),
-  };
-});
+const { mockPoolInstance, mockQueryInstance, MockPool, mockGetRootCert } =
+  vi.hoisted(() => {
+    // executeQuery now routes through pool.query().execute().close() (PR #139),
+    // so the query object is the primary execution surface.
+    const mockQueryInstance = {
+      execute: vi.fn(),
+      fetchMore: vi.fn(),
+      close: vi.fn(),
+    };
+    const mockPoolInstance = {
+      init: vi.fn(),
+      execute: vi.fn(),
+      end: vi.fn(),
+      query: vi.fn(() => mockQueryInstance),
+    };
+    return {
+      mockPoolInstance,
+      mockQueryInstance,
+      MockPool: vi.fn(() => mockPoolInstance),
+      mockGetRootCert: vi.fn().mockResolvedValue("cert"),
+    };
+  });
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -119,7 +128,16 @@ function resetMocks() {
   mockPoolInstance.init.mockReset().mockResolvedValue(undefined);
   mockPoolInstance.execute.mockReset().mockResolvedValue(SUCCESSFUL_RESULT);
   mockPoolInstance.end.mockReset().mockResolvedValue(undefined);
-  mockPoolInstance.query.mockReset();
+  // executeQuery flows through pool.query().execute().close(); re-wire the
+  // query factory each run so test-local mockImplementation overrides reset.
+  mockPoolInstance.query
+    .mockReset()
+    .mockImplementation(() => mockQueryInstance);
+  mockQueryInstance.execute.mockReset().mockResolvedValue(SUCCESSFUL_RESULT);
+  mockQueryInstance.fetchMore
+    .mockReset()
+    .mockResolvedValue({ success: true, data: [], is_done: true });
+  mockQueryInstance.close.mockReset().mockResolvedValue(undefined);
   mockGetRootCert.mockClear();
 }
 
@@ -526,15 +544,15 @@ describe("BaseConnectionPool – jdbcOptions JDBC wiring", () => {
 
     await pool.testInitializePool("test-reinit", configWithLibs, TEST_CONTEXT);
 
-    // First call: trigger timeout
-    mockPoolInstance.execute.mockReturnValueOnce(new Promise(() => {}));
+    // First call: trigger timeout on the Query.execute() path (PR #139)
+    mockQueryInstance.execute.mockReturnValueOnce(new Promise(() => {}));
     const queryPromise = pool.testExecuteQuery("test-reinit", "SELECT SLOW()");
     const assertion = expect(queryPromise).rejects.toThrow(/timed out/i);
     await vi.advanceTimersByTimeAsync(1_001);
     await assertion;
 
     // Reset execute to succeed
-    mockPoolInstance.execute.mockResolvedValue(SUCCESSFUL_RESULT);
+    mockQueryInstance.execute.mockResolvedValue(SUCCESSFUL_RESULT);
 
     // Second call: should re-init with same jdbcOptions
     await pool.testExecuteQuery("test-reinit", "SELECT 1");

--- a/tools/README.md
+++ b/tools/README.md
@@ -684,6 +684,53 @@ The `tableFormat` and `maxDisplayRows` fields are optional. If omitted, the tool
 
 ---
 
+### Fetch-Row Controls (Database Fetch Limits)
+
+> **Note:** These controls affect how many rows are **fetched from the database**, which is distinct from `maxDisplayRows` above (that only truncates the rendered markdown table).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rowsToFetch` | integer (≥ 1) | mapepire default (100) | Maximum rows fetched from the database in a single call. Use when your SQL uses `FETCH FIRST :limit ROWS ONLY` and you need more than 100. |
+| `fetchAllRows` | boolean | `false` | When `true`, fetches all rows using paginated fetches (bounded by an internal ~30k safety cap). Takes precedence over `rowsToFetch`. |
+
+**Precedence:** If both are set, `fetchAllRows` wins and `rowsToFetch` is silently ignored.
+
+**⚠️ Context-bloat warning:** Large result sets consume LLM context quickly. Prefer `rowsToFetch` with a deliberate small value; only use `fetchAllRows` for small catalogs or when the LLM has explicitly requested a full dump. A warning is logged when `rowsToFetch` exceeds 10,000.
+
+**Example — lift the 100-row cap for a single call:**
+
+```yaml
+tools:
+  list_customers:
+    source: ibmi
+    description: "List up to 500 customers"
+    rowsToFetch: 500        # lets FETCH FIRST :limit ROWS ONLY actually return 500
+    statement: |
+      SELECT ID, NAME FROM MYLIB.CUSTOMERS
+      FETCH FIRST :limit ROWS ONLY
+    parameters:
+      - name: limit
+        type: integer
+        default: 500
+        min: 1
+        max: 500
+```
+
+**Example — fetch everything (small catalogs only):**
+
+```yaml
+tools:
+  list_all_schemas:
+    source: ibmi
+    description: "List every schema (small catalog)"
+    fetchAllRows: true      # paginates until is_done, bounded by safety cap
+    statement: |
+      SELECT SCHEMA_NAME FROM QSYS2.SYSSCHEMAS
+      ORDER BY SCHEMA_NAME
+```
+
+---
+
 ### Table Format Styles
 
 The `tableFormat` field controls the visual style of result tables. Four styles are available:

--- a/tools/sample/fetch-rows-verification.yaml
+++ b/tools/sample/fetch-rows-verification.yaml
@@ -1,0 +1,108 @@
+# Verification tools for rowsToFetch / fetchAllRows (Issue #139)
+#
+# QSYS2.SYSCOLUMNS2 is a large catalog view on every IBM i system — it lists
+# every column of every table the caller can see, so it's guaranteed to have
+# far more than 100 rows. These tools let you observe each execution mode:
+#
+#   - syscolumns_default    → no row config, exercises mapepire's 100-row default
+#   - syscolumns_limited    → rowsToFetch: 500, exercises the Query.execute(n) path
+#   - syscolumns_fetch_all  → fetchAllRows: true, exercises the pagination path
+#   - syscolumns_both       → both set; fetchAllRows must win and rowsToFetch is ignored
+
+sources:
+  ibmi-verify:
+    host: ${DB2i_HOST}
+    user: ${DB2i_USER}
+    password: ${DB2i_PASS}
+    port: 8076
+    ignore-unauthorized: true
+
+tools:
+  syscolumns_default:
+    source: ibmi-verify
+    description: >
+      Baseline for issue #139 verification. Queries QSYS2.SYSCOLUMNS2 without
+      any row config — should return mapepire's default 100 rows.
+    statement: |
+      SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, LENGTH
+      FROM QSYS2.SYSCOLUMNS2
+    security:
+      readOnly: true
+    annotations:
+      readOnlyHint: true
+      idempotentHint: true
+      domain: "verification"
+      category: "fetch-rows"
+      title: "SYSCOLUMNS2 (default fetch)"
+
+  syscolumns_limited:
+    source: ibmi-verify
+    description: >
+      Demonstrates rowsToFetch=500 against QSYS2.SYSCOLUMNS2. Should return up
+      to 500 rows, confirming the per-tool fetch limit reached mapepire's
+      Query.execute(n) API.
+    statement: |
+      SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, LENGTH
+      FROM QSYS2.SYSCOLUMNS2
+    rowsToFetch: 500
+    security:
+      readOnly: true
+    annotations:
+      readOnlyHint: true
+      idempotentHint: true
+      domain: "verification"
+      category: "fetch-rows"
+      title: "SYSCOLUMNS2 (rowsToFetch=500)"
+
+  syscolumns_fetch_all:
+    source: ibmi-verify
+    description: >
+      Demonstrates fetchAllRows=true against QSYS2.SYSCOLUMNS2. Routes through
+      executeQueryWithPagination and should return thousands of rows (bounded
+      by the internal ~30k safety cap). Use sparingly — large results bloat
+      LLM context.
+    statement: |
+      SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, LENGTH
+      FROM QSYS2.SYSCOLUMNS2
+      WHERE TABLE_SCHEMA = 'QSYS2'
+    fetchAllRows: true
+    security:
+      readOnly: true
+    annotations:
+      readOnlyHint: true
+      idempotentHint: true
+      domain: "verification"
+      category: "fetch-rows"
+      title: "SYSCOLUMNS2 (fetchAllRows)"
+
+  syscolumns_both:
+    source: ibmi-verify
+    description: >
+      Precedence test — both rowsToFetch and fetchAllRows are set.
+      fetchAllRows must win; rowsToFetch is silently ignored.
+    statement: |
+      SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, LENGTH
+      FROM QSYS2.SYSCOLUMNS2
+      WHERE TABLE_SCHEMA = 'QSYS2'
+    rowsToFetch: 10
+    fetchAllRows: true
+    security:
+      readOnly: true
+    annotations:
+      readOnlyHint: true
+      idempotentHint: true
+      domain: "verification"
+      category: "fetch-rows"
+      title: "SYSCOLUMNS2 (both set → fetchAllRows wins)"
+
+toolsets:
+  fetch_rows_verification:
+    title: "Fetch-rows verification (issue #139)"
+    description: >
+      Tools that exercise each rowsToFetch / fetchAllRows execution path
+      against the large QSYS2.SYSCOLUMNS2 catalog view.
+    tools:
+      - syscolumns_default
+      - syscolumns_limited
+      - syscolumns_fetch_all
+      - syscolumns_both


### PR DESCRIPTION
## Summary

Closes #139.

YAML-defined SQL tools were silently capped at 100 rows because mapepire-js's `pool.execute()` ignores `rowsToFetch` — only `pool.query().execute(n)` honors it. This PR switches the base execution path to the `query().execute(n).close()` pattern and exposes two opt-in YAML properties:

- **`rowsToFetch: <number>`** — lifts the 100-row cap to a declared value for a single call.
- **`fetchAllRows: true`** — routes through the existing `executeQueryWithPagination()` path to fetch all rows (bounded by an internal ~30k safety cap). Takes precedence over `rowsToFetch` if both are set.

Tools that declare neither property keep today's 100-row default — **fully backward-compatible**.

Threaded through two execution paths:
- MCP server: `ToolConfigBuilder` → `SQLToolFactory.executeWithAuthRouting` → `SourceManager` / `AuthenticatedPoolManager` → `BaseConnectionPool`.
- CLI: `yaml-loader` → `cli/commands/tool.ts` → `IBMiConnectionPool.executeQuery` (this path had the same hidden cap — closed as part of this PR).

## Demo

A verification tool file is included: [`tools/sample/fetch-rows-verification.yaml`](https://github.com/IBM/ibmi-mcp-server/blob/feat/add-rows-to-fetch-cap/tools/sample/fetch-rows-verification.yaml). It defines four tools that query `QSYS2.SYSCOLUMNS2` (large catalog view) — one per execution mode.

```bash
# From repo root — requires DB2i_HOST / DB2i_USER / DB2i_PASS in env
export $(grep -v '^#' .env | xargs)

cd server && npm install && npm run build && cd ..

# 1. Baseline: no fetch config → mapepire's 100-row default
node server/dist/cli/index.js --tools ./tools/sample/fetch-rows-verification.yaml \
  --raw tool syscolumns_default | jq '.data | length'
# → 100

# 2. Per-tool limit: rowsToFetch=500
node server/dist/cli/index.js --tools ./tools/sample/fetch-rows-verification.yaml \
  --raw tool syscolumns_limited | jq '.data | length'
# → 500

# 3. Fetch everything via pagination
node server/dist/cli/index.js --tools ./tools/sample/fetch-rows-verification.yaml \
  --raw tool syscolumns_fetch_all | jq '.data | length'
# → thousands (e.g. 6764 on a typical system)

# 4. Precedence — both set, fetchAllRows wins (rowsToFetch=10 is ignored)
node server/dist/cli/index.js --tools ./tools/sample/fetch-rows-verification.yaml \
  --raw tool syscolumns_both | jq '.data | length'
# → same count as mode 3, NOT 10
```

Live verification on IBM i produced the exact expected values: **100 / 500 / 6764 / 6764**.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm run validate` — verifies the new YAML properties against the JSON schema
- [x] `npm test` — 732/732 tests pass (includes 3 new cases in `baseConnectionPool.test.ts` for `rowsToFetch` threading, `close()`-on-error, and default arg omission)
- [x] Live verification against IBM i using the four demo tools above
- [x] Docs added to [`tools/README.md`](https://github.com/IBM/ibmi-mcp-server/blob/feat/add-rows-to-fetch-cap/tools/README.md#fetch-row-controls-database-fetch-limits) with a context-bloat warning