### PR TITLE
fix(yaml): reverse rowsToFetch / fetchAllRows precedence

### DIFF
--- a/docs/sql-tools/output-formats.mdx
+++ b/docs/sql-tools/output-formats.mdx
@@ -154,6 +154,10 @@ Minimal spacing for space-constrained displays.
 
 The `maxDisplayRows` field controls how many rows are displayed before truncation occurs.
 
+<Note>
+**Display vs. fetch:** `maxDisplayRows` only truncates the rendered table — the server still fetched those rows from the database. To change how many rows are **pulled from Db2 for i**, see [`rowsToFetch` and `fetchAllRows`](/sql-tools/tools#fetch-row-controls) in the Tools Reference.
+</Note>
+
 ### Configuration
 
 **Constraints:**

--- a/docs/sql-tools/tools.mdx
+++ b/docs/sql-tools/tools.mdx
@@ -433,6 +433,109 @@ tools:
 
 ---
 
+## Fetch-Row Controls
+
+Control how many rows are **fetched from the database** per tool call. These are distinct from [`maxDisplayRows`](/sql-tools/output-formats#maximum-display-rows), which only truncates the rendered markdown table.
+
+<Note>
+**Database vs. display limits:** `rowsToFetch` / `fetchAllRows` change how many rows the server pulls from Db2 for i. `maxDisplayRows` only affects how many rows appear in the formatted output. A tool can fetch 500 rows from the database but render only the first 100 in markdown.
+</Note>
+
+### Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rowsToFetch` | integer (≥ 1) | `100` (mapepire default) | Maximum rows fetched from the database in a single call. Use when your SQL uses `FETCH FIRST :limit ROWS ONLY` and you need more than 100. Takes precedence over `fetchAllRows` when both are set. |
+| `fetchAllRows` | boolean | `false` | When `true`, fetches all rows using paginated fetches (bounded by an internal ~30,000-row safety cap). Ignored if `rowsToFetch` is also set. |
+
+<Warning>
+**Context-bloat warning:** Large result sets consume LLM context quickly. Prefer `rowsToFetch` with a deliberate small value; only use `fetchAllRows` for small catalogs or when the caller has explicitly requested a full dump. A warning is logged when `rowsToFetch` exceeds 10,000.
+</Warning>
+
+### Precedence
+
+If both `rowsToFetch` and `fetchAllRows` are set, **`rowsToFetch` wins** and `fetchAllRows` is ignored. A warning is logged so the misconfiguration is visible. Rationale: a deliberate row cap should never be silently overridden by an unbounded fetch.
+
+<Tabs>
+  <Tab title="rowsToFetch">
+    **Lift the 100-row cap for a single call**
+
+    ```yaml
+    tools:
+      list_customers:
+        source: ibmi-system
+        description: "List up to 500 customers"
+        rowsToFetch: 500          # lets FETCH FIRST :limit ROWS ONLY actually return 500
+        statement: |
+          SELECT ID, NAME FROM MYLIB.CUSTOMERS
+          FETCH FIRST :limit ROWS ONLY
+        parameters:
+          - name: limit
+            type: integer
+            default: 500
+            minimum: 1
+            maximum: 500
+    ```
+
+    **Use when:**
+    - Your `FETCH FIRST :limit ROWS ONLY` clause needs more than 100 rows
+    - You know the expected result size and want a predictable ceiling
+    - You want row-count safety without running paginated fetches
+
+    <Note>
+    Setting `rowsToFetch` alone does **not** automatically raise your SQL's `FETCH FIRST` clause — you still need a parameter or literal that matches. `rowsToFetch` is the ceiling at the driver level.
+    </Note>
+  </Tab>
+
+  <Tab title="fetchAllRows">
+    **Fetch everything (small catalogs only)**
+
+    ```yaml
+    tools:
+      list_all_schemas:
+        source: ibmi-system
+        description: "List every schema (small catalog)"
+        fetchAllRows: true        # paginates until is_done, bounded by safety cap
+        statement: |
+          SELECT SCHEMA_NAME FROM QSYS2.SYSSCHEMAS
+          ORDER BY SCHEMA_NAME
+    ```
+
+    **Use when:**
+    - The result set is known to be small (reference tables, catalogs, enums)
+    - The caller explicitly asks for a complete dump
+    - You don't know the result size up front but want completeness
+
+    <Warning>
+    Paginated fetches are bounded by a hard safety cap (~30,000 rows). Beyond that the server stops fetching — do not rely on `fetchAllRows` for true bulk exports.
+    </Warning>
+
+    <Note>
+    If you also set `rowsToFetch` on the same tool, `fetchAllRows` is ignored and a warning is logged. Pick one.
+    </Note>
+  </Tab>
+
+  <Tab title="Default (neither)">
+    **Backward-compatible 100-row cap**
+
+    ```yaml
+    tools:
+      recent_jobs:
+        source: ibmi-system
+        description: "Recent active jobs (up to 100)"
+        statement: |
+          SELECT JOB_NAME, USER_NAME, CPU_USED
+          FROM QSYS2.ACTIVE_JOB_INFO
+          ORDER BY CPU_USED DESC
+        # No rowsToFetch / fetchAllRows → 100 rows
+    ```
+
+    Tools with neither property set fetch up to **100 rows** — the mapepire driver default. This is the pre-existing behavior and requires no changes to keep working.
+  </Tab>
+</Tabs>
+
+---
+
 ## Metadata
 
 Add descriptive metadata for tool organization and discovery:

--- a/packages/cli/src/commands/tool.ts
+++ b/packages/cli/src/commands/tool.ts
@@ -301,9 +301,18 @@ async function executeTool(
     }
 
     // Execute the query, honoring YAML-declared fetch controls.
-    // fetchAllRows wins over rowsToFetch (per the locked design decision
-    // for issue #139).
-    const result = tool.fetchAllRows
+    // rowsToFetch wins over fetchAllRows: a deliberate row cap should never
+    // be silently overridden by an unbounded fetch. When both are set we
+    // emit a warning so the misconfiguration is visible.
+    if (tool.fetchAllRows && tool.rowsToFetch !== undefined) {
+      process.stderr.write(
+        `Warning: tool "${name}" sets both rowsToFetch (${tool.rowsToFetch}) and fetchAllRows; honoring rowsToFetch and ignoring fetchAllRows (safer default).\n`,
+      );
+    }
+
+    const shouldPaginate =
+      tool.fetchAllRows === true && tool.rowsToFetch === undefined;
+    const result = shouldPaginate
       ? await IBMiConnectionPool.executeQueryWithPagination(
           processedSql,
           bindingParams,

--- a/packages/server/src/ibmi-mcp-server/schemas/config.ts
+++ b/packages/server/src/ibmi-mcp-server/schemas/config.ts
@@ -217,13 +217,13 @@ export const SqlToolConfigSchema = z
       .min(1, "rowsToFetch must be at least 1")
       .optional()
       .describe(
-        "Maximum rows to fetch from the database per call (default: mapepire's 100). Controls the actual query fetch, not display truncation. Ignored if fetchAllRows is true.",
+        "Maximum rows to fetch from the database per call (default: mapepire's 100). Controls the actual query fetch, not display truncation. Takes precedence over fetchAllRows when both are set (a warning is logged).",
       ),
     fetchAllRows: z
       .boolean()
       .optional()
       .describe(
-        "When true, fetches all rows using paginated fetches (bounded by internal safety cap ~30k). Takes precedence over rowsToFetch. Use sparingly — large result sets bloat LLM context.",
+        "When true, fetches all rows using paginated fetches (bounded by internal safety cap ~30k). Ignored if rowsToFetch is also set — rowsToFetch is the safer default when both are present. Use sparingly — large result sets bloat LLM context.",
       ),
 
     // Legacy deprecated fields (for backward compatibility)

--- a/packages/server/src/ibmi-mcp-server/schemas/json/sql-tools-config.json
+++ b/packages/server/src/ibmi-mcp-server/schemas/json/sql-tools-config.json
@@ -306,11 +306,11 @@
               "rowsToFetch": {
                 "type": "integer",
                 "minimum": 1,
-                "description": "Maximum rows to fetch from the database per call (default: mapepire's 100). Controls the actual query fetch, not display truncation. Ignored if fetchAllRows is true."
+                "description": "Maximum rows to fetch from the database per call (default: mapepire's 100). Controls the actual query fetch, not display truncation. Takes precedence over fetchAllRows when both are set (a warning is logged)."
               },
               "fetchAllRows": {
                 "type": "boolean",
-                "description": "When true, fetches all rows using paginated fetches (bounded by internal safety cap ~30k). Takes precedence over rowsToFetch. Use sparingly — large result sets bloat LLM context."
+                "description": "When true, fetches all rows using paginated fetches (bounded by internal safety cap ~30k). Ignored if rowsToFetch is also set — rowsToFetch is the safer default when both are present. Use sparingly — large result sets bloat LLM context."
               },
               "readOnlyHint": {
                 "type": "boolean",

--- a/packages/server/src/ibmi-mcp-server/utils/config/toolFactory.ts
+++ b/packages/server/src/ibmi-mcp-server/utils/config/toolFactory.ts
@@ -278,9 +278,22 @@ export class SQLToolFactory {
     // Check for IBM i authentication context
     const authInfo = authContext.getStore()?.authInfo;
 
-    // fetchAllRows wins over rowsToFetch. Routes through the
-    // executeQueryWithPagination path (mapepire pool.query().fetchMore loop).
-    if (fetchAllRows) {
+    // rowsToFetch wins over fetchAllRows. A deliberate row cap should never
+    // be silently overridden by an unbounded fetch, so we only take the
+    // paginated path when fetchAllRows is the sole directive.
+    if (fetchAllRows && rowsToFetch !== undefined) {
+      logger.warning(
+        {
+          ...context,
+          sourceName,
+          rowsToFetch,
+          fetchAllRows: true,
+        },
+        "Both rowsToFetch and fetchAllRows are set; honoring rowsToFetch and ignoring fetchAllRows (safer default).",
+      );
+    }
+
+    if (fetchAllRows && rowsToFetch === undefined) {
       logger.debug(
         {
           ...context,

--- a/packages/server/tests/ibmi-mcp-server/utils/config/toolFactory.precedence.test.ts
+++ b/packages/server/tests/ibmi-mcp-server/utils/config/toolFactory.precedence.test.ts
@@ -1,0 +1,169 @@
+/**
+ * @fileoverview Precedence tests for SQLToolFactory fetch controls.
+ *
+ * Verifies the rowsToFetch vs fetchAllRows decision in
+ * SQLToolFactory.executeWithAuthRouting (issue #139 follow-up):
+ *   - rowsToFetch alone  → executeQuery(rowsToFetch)
+ *   - fetchAllRows alone → executeQueryWithPagination
+ *   - both set           → executeQuery(rowsToFetch) + WARN logged,
+ *                          executeQueryWithPagination NOT called
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Override the global logger no-op mock with spies so we can assert the warn.
+// vi.hoisted lets us reference these symbols from the hoisted vi.mock factory.
+const { warningSpy } = vi.hoisted(() => ({ warningSpy: vi.fn() }));
+
+vi.mock("../../../../src/utils/internal/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    warning: warningSpy,
+    error: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+// Block the scheduler singleton (loaded transitively via the utils barrel).
+vi.mock("../../../../src/utils/scheduling/index.js", () => ({
+  SchedulerService: { getInstance: vi.fn() },
+  schedulerService: {},
+}));
+
+import { SQLToolFactory } from "../../../../src/ibmi-mcp-server/utils/config/toolFactory.js";
+import type { SourceManager } from "../../../../src/ibmi-mcp-server/services/sourceManager.js";
+
+/**
+ * Minimal mapepire-compatible QueryResult for the executeQuery path.
+ */
+function makeExecuteResult() {
+  return {
+    success: true,
+    data: [],
+    metadata: { columns: [] },
+    sql_rc: 0,
+    execution_time: 1,
+    is_done: true,
+    has_results: false,
+    update_count: 0,
+    id: "",
+    sql_state: "",
+  };
+}
+
+/**
+ * Minimal paginated result shape consumed by toolFactory at lines 312-325.
+ */
+function makePaginatedResult() {
+  return {
+    success: true,
+    data: [],
+    metadata: { columns: [] },
+    sql_rc: 0,
+    execution_time: 1,
+  };
+}
+
+/**
+ * Builds a stub SourceManager that exposes spied versions of the two methods
+ * the factory chooses between. Only the properties SQLToolFactory touches
+ * need to be present — the rest of the SourceManager surface is unused here.
+ */
+function makeStubSourceManager() {
+  const executeQuery = vi.fn().mockResolvedValue(makeExecuteResult());
+  const executeQueryWithPagination = vi
+    .fn()
+    .mockResolvedValue(makePaginatedResult());
+  const stub = {
+    executeQuery,
+    executeQueryWithPagination,
+  } as unknown as SourceManager;
+  return { stub, executeQuery, executeQueryWithPagination };
+}
+
+describe("SQLToolFactory fetch-control precedence", () => {
+  beforeEach(() => {
+    warningSpy.mockClear();
+  });
+
+  it("only rowsToFetch → executeQuery called with rowsToFetch, no pagination", async () => {
+    const { stub, executeQuery, executeQueryWithPagination } =
+      makeStubSourceManager();
+    SQLToolFactory.initialize(stub);
+
+    await SQLToolFactory.executeStatementWithParameters(
+      "t",
+      "ibmi",
+      "SELECT 1",
+      {},
+      [],
+      undefined,
+      undefined,
+      500,
+      undefined,
+    );
+
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+    const args = executeQuery.mock.calls[0];
+    expect(args[args.length - 1]).toBe(500);
+    expect(executeQueryWithPagination).not.toHaveBeenCalled();
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+
+  it("only fetchAllRows → executeQueryWithPagination called, no executeQuery", async () => {
+    const { stub, executeQuery, executeQueryWithPagination } =
+      makeStubSourceManager();
+    SQLToolFactory.initialize(stub);
+
+    await SQLToolFactory.executeStatementWithParameters(
+      "t",
+      "ibmi",
+      "SELECT 1",
+      {},
+      [],
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(executeQueryWithPagination).toHaveBeenCalledTimes(1);
+    expect(executeQuery).not.toHaveBeenCalled();
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+
+  it("both set → rowsToFetch wins, fetchAllRows ignored, WARN emitted", async () => {
+    const { stub, executeQuery, executeQueryWithPagination } =
+      makeStubSourceManager();
+    SQLToolFactory.initialize(stub);
+
+    await SQLToolFactory.executeStatementWithParameters(
+      "t",
+      "ibmi",
+      "SELECT 1",
+      {},
+      [],
+      undefined,
+      undefined,
+      500,
+      true,
+    );
+
+    expect(executeQuery).toHaveBeenCalledTimes(1);
+    const args = executeQuery.mock.calls[0];
+    expect(args[args.length - 1]).toBe(500);
+    expect(executeQueryWithPagination).not.toHaveBeenCalled();
+
+    expect(warningSpy).toHaveBeenCalledTimes(1);
+    const [logCtx, logMsg] = warningSpy.mock.calls[0] as [
+      Record<string, unknown>,
+      string,
+    ];
+    expect(logCtx).toMatchObject({ rowsToFetch: 500, fetchAllRows: true });
+    expect(logMsg).toMatch(/rowsToFetch/);
+    expect(logMsg).toMatch(/fetchAllRows/);
+  });
+});

--- a/tools/README.md
+++ b/tools/README.md
@@ -690,10 +690,10 @@ The `tableFormat` and `maxDisplayRows` fields are optional. If omitted, the tool
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `rowsToFetch` | integer (≥ 1) | mapepire default (100) | Maximum rows fetched from the database in a single call. Use when your SQL uses `FETCH FIRST :limit ROWS ONLY` and you need more than 100. |
-| `fetchAllRows` | boolean | `false` | When `true`, fetches all rows using paginated fetches (bounded by an internal ~30k safety cap). Takes precedence over `rowsToFetch`. |
+| `rowsToFetch` | integer (≥ 1) | mapepire default (100) | Maximum rows fetched from the database in a single call. Use when your SQL uses `FETCH FIRST :limit ROWS ONLY` and you need more than 100. Takes precedence over `fetchAllRows` when both are set. |
+| `fetchAllRows` | boolean | `false` | When `true`, fetches all rows using paginated fetches (bounded by an internal ~30k safety cap). Ignored if `rowsToFetch` is also set. |
 
-**Precedence:** If both are set, `fetchAllRows` wins and `rowsToFetch` is silently ignored.
+**Precedence:** If both are set, `rowsToFetch` wins and `fetchAllRows` is ignored (a warning is logged). Rationale: a deliberate row cap should never be silently overridden by an unbounded fetch.
 
 **⚠️ Context-bloat warning:** Large result sets consume LLM context quickly. Prefer `rowsToFetch` with a deliberate small value; only use `fetchAllRows` for small catalogs or when the LLM has explicitly requested a full dump. A warning is logged when `rowsToFetch` exceeds 10,000.
 


### PR DESCRIPTION
When both fetch controls are set, honor rowsToFetch and ignore fetchAllRows (with a warning logged). A deliberate row cap should never be silently overridden by an unbounded paginated fetch — this is the safer default for both server and CLI paths.

- toolFactory.executeWithAuthRouting takes the paginated path only when fetchAllRows is the sole directive; conflict emits a WARN
- CLI `ibmi tool` mirrors the same rule, surfacing the conflict via stderr
- Zod + generated JSON schema descriptions updated
- Docs: tools/README.md, docs/sql-tools/tools.mdx, and a new cross-reference in docs/sql-tools/output-formats.mdx
- New test: toolFactory.precedence.test.ts covers all three matrix cells (rowsToFetch only, fetchAllRows only, both set)