### PR TITLE
feat: compose rowsToFetch and fetchAllRows, centralize pagination limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -216,6 +216,22 @@ MCP_POOL_IDLE_TIMEOUT_MS=300000
 MCP_POOL_QUERY_TIMEOUT_MS=30000
 
 # -----------------------------------------------------------------------------
+# 📄 Pagination
+# -----------------------------------------------------------------------------
+# Controls the fetch size and safety ceiling used by SQL tools that paginate
+# large result sets (fetchAllRows: true or the built-in execute_sql tool).
+
+# Default rows per fetchMore call when a tool paginates without specifying
+# its own page size. Tools can override by setting rowsToFetch in YAML.
+# Default: 1000
+IBMI_PAGINATION_DEFAULT_PAGE_SIZE=1000
+
+# Hard upper bound on total rows returned by a single paginated tool call.
+# Pagination stops and flags the result as truncated once this is reached.
+# Default: 30000
+IBMI_PAGINATION_MAX_ROWS=30000
+
+# -----------------------------------------------------------------------------
 # 🔐 Authentication & Authorization
 # -----------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.5.1](https://github.com/IBM/ibmi-mcp-server/compare/v0.5.0...v0.5.1)
+
+Consolidates the fetch-limit UX introduced in 0.5.0 before downstream adoption locks in the current behavior.
+
+### Changed
+
+* **`rowsToFetch` and `fetchAllRows` now compose instead of colliding.** `fetchAllRows: true` is the pagination policy; when `rowsToFetch` is also set it becomes the per-fetch page size. The previous "`rowsToFetch` wins, `fetchAllRows` ignored" precedence rule has been removed — the warning log it emitted is gone too, since the two fields no longer conflict. YAML tools that set only one field behave identically; tools that set both now paginate with a custom page size instead of silently ignoring `fetchAllRows`.
+
+* **Pagination safety ceiling is now row-based, not iteration-based.** The internal loop now terminates at `IBMI_PAGINATION_MAX_ROWS` rows of accumulated data rather than at 100 `fetchMore` iterations, so the effective row ceiling is stable regardless of per-fetch page size. Previously a larger page size implicitly granted a proportionally larger cap. When a result is truncated at the ceiling, the server emits a warning log and flags the response; the CLI surfaces the truncation in its output footer.
+
+* **`execute_sql` built-in tool inherits shared pagination defaults.** Previously hard-coded a 1000-row page size, producing an effective ~100,000-row ceiling inconsistent with YAML tools. Now reads `IBMI_PAGINATION_DEFAULT_PAGE_SIZE` / `IBMI_PAGINATION_MAX_ROWS` from config — matching every YAML tool and the documented 30,000-row cap. Operators running bulk CLI exports can raise `IBMI_PAGINATION_MAX_ROWS`.
+
+### Added
+
+* **Two new environment variables** for tuning pagination:
+  * `IBMI_PAGINATION_DEFAULT_PAGE_SIZE` (default `1000`) — rows per `fetchMore` call when a tool paginates without specifying its own page size.
+  * `IBMI_PAGINATION_MAX_ROWS` (default `30000`) — hard upper bound on total rows from a paginated tool call.
+
+* **CLI truncation display.** The `ibmi tool run` footer now shows `(result capped — raise IBMI_PAGINATION_MAX_ROWS or narrow the query)` when a paginated result hits the ceiling, so callers know the output was clipped.
+
+### Migration
+
+No YAML changes required. Tools that set only `rowsToFetch` or only `fetchAllRows` behave as before. Tools that set **both** fields will now paginate with the custom page size instead of the previous "`rowsToFetch` wins" behavior — if that transition is undesirable, remove `fetchAllRows`. Callers relying on `execute_sql` to return up to ~100,000 rows should raise `IBMI_PAGINATION_MAX_ROWS` explicitly; otherwise the effective ceiling is now the documented 30,000.
+
 ## [0.5.0](https://github.com/IBM/ibmi-mcp-server/compare/v0.4.5...v0.5.0) (2026-04-20)
 
 This release splits the `ibmi` command-line tool into its own `@ibm/ibmi-cli` npm package, adds first-class JDBC connection tuning to YAML sources, introduces per-tool row-fetch controls, and extends the SQL security validator to cover `ibmi tool` execution.

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -250,6 +250,19 @@ Below is the reference for core server configuration options. Each section inclu
 **Setting `MCP_POOL_QUERY_TIMEOUT_MS=0` disables query timeouts entirely.** This means queries on dead connections will hang until the client's own timeout fires. Only disable this in trusted, stable network environments.
 </Warning>
 
+### Pagination
+
+**Controls the per-fetch page size and the safety ceiling used when SQL tools paginate large result sets.** `fetchAllRows: true` tools and the built-in `execute_sql` tool share these values. YAML tools override per-call via `rowsToFetch`; these env vars govern the defaults.
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `IBMI_PAGINATION_DEFAULT_PAGE_SIZE` | Rows per `fetchMore` call when a tool paginates without specifying its own page size. | `1000` | `500` |
+| `IBMI_PAGINATION_MAX_ROWS` | Hard upper bound on total rows from a single paginated tool call. Pagination stops and flags the result as truncated once this is reached. | `30000` | `100000` |
+
+<Info>
+**Why these defaults:** At 1000 rows/fetch, the server makes at most 30 round-trips before hitting the 30,000-row ceiling — around 3 seconds of tail latency on a healthy WebSocket link. The ceiling itself is the practical LLM-ingestion limit: 30k rows typically serialize to 3-6M tokens, already beyond most context windows. Operators running bulk CLI exports can raise `IBMI_PAGINATION_MAX_ROWS`; LLM-facing deployments rarely should.
+</Info>
+
 ## Authentication Configuration
 
 ### Choosing an Authentication Mode

--- a/docs/sql-tools/output-formats.mdx
+++ b/docs/sql-tools/output-formats.mdx
@@ -155,7 +155,7 @@ Minimal spacing for space-constrained displays.
 The `maxDisplayRows` field controls how many rows are displayed before truncation occurs.
 
 <Note>
-**Display vs. fetch:** `maxDisplayRows` only truncates the rendered table — the server still fetched those rows from the database. To change how many rows are **pulled from Db2 for i**, see [`rowsToFetch` and `fetchAllRows`](/sql-tools/tools#fetch-row-controls) in the Tools Reference.
+**Display vs. fetch:** `maxDisplayRows` only truncates the rendered table — the server still fetched those rows from the database. To change how many rows are **pulled from Db2 for i**, see [fetch-row controls](/sql-tools/tools#fetch-row-controls) in the Tools Reference.
 </Note>
 
 ### Configuration

--- a/docs/sql-tools/tools.mdx
+++ b/docs/sql-tools/tools.mdx
@@ -443,21 +443,29 @@ Control how many rows are **fetched from the database** per tool call. These are
 
 ### Fields
 
+The two fields **compose**: `fetchAllRows` is the pagination *policy*; `rowsToFetch`, when set, is the per-fetch *size* in pagination mode, or a single-shot row cap when `fetchAllRows` is off.
+
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `rowsToFetch` | integer (≥ 1) | `100` (mapepire default) | Maximum rows fetched from the database in a single call. Use when your SQL uses `FETCH FIRST :limit ROWS ONLY` and you need more than 100. Takes precedence over `fetchAllRows` when both are set. |
-| `fetchAllRows` | boolean | `false` | When `true`, fetches all rows using paginated fetches (bounded by an internal ~30,000-row safety cap). Ignored if `rowsToFetch` is also set. |
+| `rowsToFetch` | integer (≥ 1) | `100` (mapepire default) | With `fetchAllRows: true`, the number of rows per `fetchMore` call. Without `fetchAllRows`, a single-shot cap applied to `FETCH FIRST :limit ROWS ONLY`-style queries. |
+| `fetchAllRows` | boolean | `false` | When `true`, paginate until the database reports `is_done` or the safety ceiling (`IBMI_PAGINATION_MAX_ROWS`, default `30000`) is reached. |
+
+### Composition
+
+| Config | Behavior |
+|---|---|
+| `rowsToFetch: N` alone | Single-shot `execute(N)` — up to N rows, one round-trip |
+| `fetchAllRows: true` alone | Paginate with `IBMI_PAGINATION_DEFAULT_PAGE_SIZE` (default `1000`) per fetch |
+| `fetchAllRows: true, rowsToFetch: N` | Paginate with **N rows per fetch** — tune per tool for wide rows |
+
+When the paginated result hits `IBMI_PAGINATION_MAX_ROWS`, the server truncates the rows returned and emits a warning log. The CLI surfaces the truncation in the output footer so callers know the result was clipped.
 
 <Warning>
-**Context-bloat warning:** Large result sets consume LLM context quickly. Prefer `rowsToFetch` with a deliberate small value; only use `fetchAllRows` for small catalogs or when the caller has explicitly requested a full dump. A warning is logged when `rowsToFetch` exceeds 10,000.
+**Context-bloat warning:** Large result sets consume LLM context quickly. Prefer `rowsToFetch` with a deliberate small value; only use `fetchAllRows` for small catalogs or when the caller has explicitly requested a full dump.
 </Warning>
 
-### Precedence
-
-If both `rowsToFetch` and `fetchAllRows` are set, **`rowsToFetch` wins** and `fetchAllRows` is ignored. A warning is logged so the misconfiguration is visible. Rationale: a deliberate row cap should never be silently overridden by an unbounded fetch.
-
 <Tabs>
-  <Tab title="rowsToFetch">
+  <Tab title="rowsToFetch (single-shot)">
     **Lift the 100-row cap for a single call**
 
     ```yaml
@@ -487,7 +495,7 @@ If both `rowsToFetch` and `fetchAllRows` are set, **`rowsToFetch` wins** and `fe
     </Note>
   </Tab>
 
-  <Tab title="fetchAllRows">
+  <Tab title="fetchAllRows (paginate)">
     **Fetch everything (small catalogs only)**
 
     ```yaml
@@ -495,7 +503,7 @@ If both `rowsToFetch` and `fetchAllRows` are set, **`rowsToFetch` wins** and `fe
       list_all_schemas:
         source: ibmi-system
         description: "List every schema (small catalog)"
-        fetchAllRows: true        # paginates until is_done, bounded by safety cap
+        fetchAllRows: true        # paginates until is_done, bounded by IBMI_PAGINATION_MAX_ROWS
         statement: |
           SELECT SCHEMA_NAME FROM QSYS2.SYSSCHEMAS
           ORDER BY SCHEMA_NAME
@@ -507,11 +515,33 @@ If both `rowsToFetch` and `fetchAllRows` are set, **`rowsToFetch` wins** and `fe
     - You don't know the result size up front but want completeness
 
     <Warning>
-    Paginated fetches are bounded by a hard safety cap (~30,000 rows). Beyond that the server stops fetching — do not rely on `fetchAllRows` for true bulk exports.
+    Paginated fetches are bounded by `IBMI_PAGINATION_MAX_ROWS` (default `30000`). Beyond that the server truncates and flags the result — do not rely on `fetchAllRows` for true bulk exports.
     </Warning>
+  </Tab>
+
+  <Tab title="Paginate with custom page size">
+    **Compose both fields for wide-row tables**
+
+    ```yaml
+    tools:
+      export_all_columns:
+        source: ibmi-system
+        description: "Stream every column of every table in SAMPLE"
+        fetchAllRows: true        # paginate until exhausted
+        rowsToFetch: 500          # 500 rows per fetchMore call
+        statement: |
+          SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, LENGTH
+          FROM QSYS2.SYSCOLUMNS2
+          WHERE TABLE_SCHEMA = 'SAMPLE'
+    ```
+
+    **Use when:**
+    - The result set is large **and** you need a smaller per-fetch page (wide rows, memory-sensitive environments)
+    - The default page size (1000) produces fetches that are too large for your link
+    - You want explicit control over the WebSocket round-trip/memory tradeoff per tool
 
     <Note>
-    If you also set `rowsToFetch` on the same tool, `fetchAllRows` is ignored and a warning is logged. Pick one.
+    Both fields working together is the most expressive option: policy (paginate) and size (per-fetch page) are independent knobs. `rowsToFetch` without `fetchAllRows` stays a single-shot cap.
     </Note>
   </Tab>
 

--- a/packages/cli/src/commands/sql.ts
+++ b/packages/cli/src/commands/sql.ts
@@ -158,10 +158,19 @@ export function registerSqlCommand(program: Command): void {
           throw new Error(result.error?.message ?? "SQL execution failed");
         }
 
+        // execute_sql paginates at the service layer and flags `truncated`
+        // when it hits IBMI_PAGINATION_MAX_ROWS. Surface that in the footer
+        // so `ibmi sql` users see the same truncation hint `ibmi tool` shows.
+        const truncated = result.truncated === true;
+
         return {
           data: (result.data ?? []) as Record<string, unknown>[],
           meta: {
             rowCount: result.rowCount ?? 0,
+            hasMore: truncated,
+            truncationHint: truncated
+              ? "(result capped — raise IBMI_PAGINATION_MAX_ROWS or narrow the query)"
+              : undefined,
           },
         };
       });

--- a/packages/cli/src/commands/tool.ts
+++ b/packages/cli/src/commands/tool.ts
@@ -321,6 +321,11 @@ async function executeTool(
     const elapsedMs = Date.now() - startTime;
     const data = (result.data ?? []) as Record<string, unknown>[];
 
+    // The paginated path returns a `truncated` flag when the server hit
+    // MAX_PAGINATION_ROWS. Surface it in the output footer so users know
+    // the result set was clipped and how to get more.
+    const truncated = "truncated" in result && result.truncated === true;
+
     // NDJSON streaming: one JSON object per line
     if (stream && format === "json") {
       renderNdjson(data);
@@ -332,6 +337,10 @@ async function executeTool(
       elapsedMs,
       system: resolved,
       command: `tool:${name}`,
+      hasMore: truncated,
+      truncationHint: truncated
+        ? "(result capped — raise IBMI_PAGINATION_MAX_ROWS or narrow the query)"
+        : undefined,
     });
   } finally {
     await cleanup();

--- a/packages/cli/src/commands/tool.ts
+++ b/packages/cli/src/commands/tool.ts
@@ -300,23 +300,16 @@ async function executeTool(
       );
     }
 
-    // Execute the query, honoring YAML-declared fetch controls.
-    // rowsToFetch wins over fetchAllRows: a deliberate row cap should never
-    // be silently overridden by an unbounded fetch. When both are set we
-    // emit a warning so the misconfiguration is visible.
-    if (tool.fetchAllRows && tool.rowsToFetch !== undefined) {
-      process.stderr.write(
-        `Warning: tool "${name}" sets both rowsToFetch (${tool.rowsToFetch}) and fetchAllRows; honoring rowsToFetch and ignoring fetchAllRows (safer default).\n`,
-      );
-    }
-
-    const shouldPaginate =
-      tool.fetchAllRows === true && tool.rowsToFetch === undefined;
-    const result = shouldPaginate
+    // Execute the query, honoring YAML-declared fetch controls. When
+    // fetchAllRows is set we paginate; rowsToFetch (if present) becomes
+    // the per-fetch page size. Otherwise rowsToFetch caps the single-shot
+    // execute() call.
+    const result = tool.fetchAllRows
       ? await IBMiConnectionPool.executeQueryWithPagination(
           processedSql,
           bindingParams,
           ctx,
+          tool.rowsToFetch,
         )
       : await IBMiConnectionPool.executeQuery(
           processedSql,

--- a/packages/cli/src/formatters/output.ts
+++ b/packages/cli/src/formatters/output.ts
@@ -58,6 +58,13 @@ export interface OutputMeta {
   rowCount: number;
   /** Whether more rows exist beyond the current result. */
   hasMore?: boolean;
+  /**
+   * Human-readable hint shown in the table footer when hasMore is true.
+   * Overrides the default "(more available — use --limit/--offset)" text
+   * so commands that have no --limit/--offset flags can offer relevant
+   * guidance (e.g. raising an env var or narrowing the query).
+   */
+  truncationHint?: string;
   /** Time taken for the query in milliseconds. */
   elapsedMs?: number;
   /** The resolved system used for this command. */
@@ -194,7 +201,9 @@ function renderTable(
     parts.push(`${meta.rowCount} row${meta.rowCount !== 1 ? "s" : ""}`);
   }
   if (meta?.hasMore) {
-    parts.push("(more available — use --limit/--offset)");
+    parts.push(
+      meta.truncationHint ?? "(more available — use --limit/--offset)",
+    );
   }
   if (meta?.elapsedMs !== undefined) {
     parts.push(`${(meta.elapsedMs / 1000).toFixed(2)}s`);

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -216,6 +216,22 @@ MCP_POOL_IDLE_TIMEOUT_MS=300000
 MCP_POOL_QUERY_TIMEOUT_MS=30000
 
 # -----------------------------------------------------------------------------
+# 📄 Pagination
+# -----------------------------------------------------------------------------
+# Controls the fetch size and safety ceiling used by SQL tools that paginate
+# large result sets (fetchAllRows: true or the built-in execute_sql tool).
+
+# Default rows per fetchMore call when a tool paginates without specifying
+# its own page size. Tools can override by setting rowsToFetch in YAML.
+# Default: 1000
+IBMI_PAGINATION_DEFAULT_PAGE_SIZE=1000
+
+# Hard upper bound on total rows returned by a single paginated tool call.
+# Pagination stops and flags the result as truncated once this is reached.
+# Default: 30000
+IBMI_PAGINATION_MAX_ROWS=30000
+
+# -----------------------------------------------------------------------------
 # 🔐 Authentication & Authorization
 # -----------------------------------------------------------------------------
 

--- a/packages/server/src/config/index.ts
+++ b/packages/server/src/config/index.ts
@@ -393,6 +393,27 @@ const EnvSchema = z.object({
     .nonnegative()
     .default(30_000),
   // --- END: Connection Pool Timeout Configuration ---
+
+  // --- START: Pagination Configuration ---
+  /**
+   * Default page size for paginated SQL fetches (rows per fetchMore call).
+   * Used when a tool sets fetchAllRows: true without specifying rowsToFetch.
+   * Also the fetch size used by the built-in execute_sql tool.
+   * Default: 1000.
+   */
+  IBMI_PAGINATION_DEFAULT_PAGE_SIZE: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(1000),
+
+  /**
+   * Hard upper bound on total rows returned by a single paginated tool call.
+   * The pagination loop stops once accumulated rows reach this value, even
+   * if the result set has more data. Default: 30000.
+   */
+  IBMI_PAGINATION_MAX_ROWS: z.coerce.number().int().positive().default(30_000),
+  // --- END: Pagination Configuration ---
 });
 
 const parsedEnv = EnvSchema.safeParse(process.env);
@@ -705,6 +726,12 @@ export const config = {
     idleTimeoutMs: env.MCP_POOL_IDLE_TIMEOUT_MS,
     queryTimeoutMs: env.MCP_POOL_QUERY_TIMEOUT_MS,
   },
+
+  /** Pagination configuration for SQL tool fetches. From `IBMI_PAGINATION_*` environment variables. */
+  pagination: {
+    defaultPageSize: env.IBMI_PAGINATION_DEFAULT_PAGE_SIZE,
+    maxRows: env.IBMI_PAGINATION_MAX_ROWS,
+  },
 };
 
 if (config.ibmiHttpAuth.enabled) {
@@ -728,3 +755,18 @@ if (config.ibmiHttpAuth.enabled) {
 
 export const logLevel: string = config.logLevel;
 export const environment: string = config.environment;
+
+/**
+ * Default number of rows fetched per `fetchMore` call when a tool paginates
+ * without specifying its own page size. Sourced from
+ * `IBMI_PAGINATION_DEFAULT_PAGE_SIZE` (default 1000).
+ */
+export const DEFAULT_PAGE_SIZE: number = config.pagination.defaultPageSize;
+
+/**
+ * Upper bound on total rows returned by a single paginated tool call. The
+ * pagination loop terminates once accumulated rows reach this value and
+ * flags the result as truncated. Sourced from `IBMI_PAGINATION_MAX_ROWS`
+ * (default 30000).
+ */
+export const MAX_PAGINATION_ROWS: number = config.pagination.maxRows;

--- a/packages/server/src/ibmi-mcp-server/services/authenticatedPoolManager.ts
+++ b/packages/server/src/ibmi-mcp-server/services/authenticatedPoolManager.ts
@@ -261,7 +261,7 @@ export class AuthenticatedPoolManager extends BaseConnectionPool<string> {
     query: string,
     params?: BindingValue[],
     context?: RequestContext,
-    fetchSize: number = 300,
+    fetchSize?: number,
     securityConfig?: SqlToolSecurityConfig,
   ) {
     const operationContext =

--- a/packages/server/src/ibmi-mcp-server/services/baseConnectionPool.ts
+++ b/packages/server/src/ibmi-mcp-server/services/baseConnectionPool.ts
@@ -21,7 +21,11 @@ import {
 import { JsonRpcErrorCode, McpError } from "@/types-global/errors.js";
 import { SqlToolSecurityConfig } from "@/ibmi-mcp-server/schemas/index.js";
 import { SqlSecurityValidator } from "../utils/security/sqlSecurityValidator.js";
-import { config, DEFAULT_PAGE_SIZE } from "@/config/index.js";
+import {
+  config,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGINATION_ROWS,
+} from "@/config/index.js";
 
 /**
  * Pool health status values used across pool interfaces and return types
@@ -585,6 +589,7 @@ export abstract class BaseConnectionPool<TId extends string | symbol = string> {
     sql_rc?: unknown;
     execution_time?: number;
     metadata?: QueryMetaData;
+    truncated: boolean;
   }> {
     const operationContext =
       context ||
@@ -652,10 +657,11 @@ export abstract class BaseConnectionPool<TId extends string | symbol = string> {
           allData.push(...result.data);
         }
 
-        // Fetch more results until done
+        // Fetch more results until done or safety cap reached. The cap is
+        // row-based so the effective ceiling is stable regardless of
+        // per-fetch page size — see MAX_PAGINATION_ROWS.
         let fetchCount = 1;
-        while (!result.is_done && fetchCount < 100) {
-          // Safety limit
+        while (!result.is_done && allData.length < MAX_PAGINATION_ROWS) {
           logger.debug(
             {
               ...operationContext,
@@ -674,14 +680,36 @@ export abstract class BaseConnectionPool<TId extends string | symbol = string> {
           fetchCount++;
         }
 
+        // Truncate to MAX_PAGINATION_ROWS exactly when the final page
+        // overshoots the cap. Callers should not see more rows than promised.
+        const truncated =
+          !result.is_done || allData.length >= MAX_PAGINATION_ROWS;
+        if (allData.length > MAX_PAGINATION_ROWS) {
+          allData.length = MAX_PAGINATION_ROWS;
+        }
+
         // Close the query
         await queryObj.close();
+
+        if (truncated) {
+          logger.warning(
+            {
+              ...operationContext,
+              totalRows: allData.length,
+              cap: MAX_PAGINATION_ROWS,
+              fetchCount,
+              fetchSize,
+            },
+            "Paginated query hit row cap — result is truncated. Raise IBMI_PAGINATION_MAX_ROWS or narrow the query.",
+          );
+        }
 
         logger.debug(
           {
             ...operationContext,
             totalRows: allData.length,
             fetchCount,
+            truncated,
             success: result.success,
             sqlReturnCode: result.sql_rc,
             executionTime: result.execution_time,
@@ -698,6 +726,7 @@ export abstract class BaseConnectionPool<TId extends string | symbol = string> {
           sql_rc: result.sql_rc,
           execution_time: result.execution_time,
           metadata: initialMetadata,
+          truncated,
         };
       },
       {

--- a/packages/server/src/ibmi-mcp-server/services/baseConnectionPool.ts
+++ b/packages/server/src/ibmi-mcp-server/services/baseConnectionPool.ts
@@ -21,7 +21,7 @@ import {
 import { JsonRpcErrorCode, McpError } from "@/types-global/errors.js";
 import { SqlToolSecurityConfig } from "@/ibmi-mcp-server/schemas/index.js";
 import { SqlSecurityValidator } from "../utils/security/sqlSecurityValidator.js";
-import { config } from "@/config/index.js";
+import { config, DEFAULT_PAGE_SIZE } from "@/config/index.js";
 
 /**
  * Pool health status values used across pool interfaces and return types
@@ -577,7 +577,7 @@ export abstract class BaseConnectionPool<TId extends string | symbol = string> {
     query: string,
     params?: BindingValue[],
     context?: RequestContext,
-    fetchSize: number = 300,
+    fetchSize: number = DEFAULT_PAGE_SIZE,
     securityConfig?: SqlToolSecurityConfig,
   ): Promise<{
     data: unknown[];

--- a/packages/server/src/ibmi-mcp-server/services/connectionPool.ts
+++ b/packages/server/src/ibmi-mcp-server/services/connectionPool.ts
@@ -115,7 +115,7 @@ export class IBMiConnectionPool extends BaseConnectionPool<
     query: string,
     params?: BindingValue[],
     context?: RequestContext,
-    fetchSize: number = 300,
+    fetchSize?: number,
   ): Promise<{
     data: unknown[];
     success: boolean;

--- a/packages/server/src/ibmi-mcp-server/services/connectionPool.ts
+++ b/packages/server/src/ibmi-mcp-server/services/connectionPool.ts
@@ -122,6 +122,7 @@ export class IBMiConnectionPool extends BaseConnectionPool<
     sql_rc?: unknown;
     execution_time?: number;
     metadata?: QueryMetaData;
+    truncated: boolean;
   }> {
     const operationContext =
       context ||

--- a/packages/server/src/ibmi-mcp-server/services/sourceManager.ts
+++ b/packages/server/src/ibmi-mcp-server/services/sourceManager.ts
@@ -174,7 +174,7 @@ export class SourceManager extends BaseConnectionPool<string> {
     query: string,
     params?: BindingValue[],
     context?: RequestContext,
-    fetchSize: number = 300,
+    fetchSize?: number,
     securityConfig?: SqlToolSecurityConfig,
   ) {
     return super.executeQueryWithPagination(

--- a/packages/server/src/ibmi-mcp-server/tools/executeSql.tool.ts
+++ b/packages/server/src/ibmi-mcp-server/tools/executeSql.tool.ts
@@ -329,12 +329,14 @@ async function executeSqlLogic(
       appContext,
     );
 
-    // Execute the query with sanitized SQL
+    // Execute the query with sanitized SQL. Fetch size and the overall
+    // row cap are controlled by IBMI_PAGINATION_* env vars at the
+    // service layer, so execute_sql inherits the same ceiling as any
+    // YAML tool that paginates.
     const result = await IBMiConnectionPool.executeQueryWithPagination(
       sanitizedSql,
       [],
       appContext,
-      1000, // Fetch 1000 rows at a time
     );
 
     const executionTime = Date.now() - startTime;

--- a/packages/server/src/ibmi-mcp-server/tools/executeSql.tool.ts
+++ b/packages/server/src/ibmi-mcp-server/tools/executeSql.tool.ts
@@ -146,6 +146,12 @@ const ExecuteSqlResponseSchema = z.object({
     .number()
     .optional()
     .describe("Query execution time in milliseconds."),
+  truncated: z
+    .boolean()
+    .optional()
+    .describe(
+      "True when the result set hit the IBMI_PAGINATION_MAX_ROWS safety cap and was clipped. The returned rows are a prefix of the full result — raise the cap or narrow the query to see more.",
+    ),
   metadata: z
     .object({
       columns: z
@@ -365,6 +371,7 @@ async function executeSqlLogic(
       data: typedData,
       rowCount: typedData?.length ?? 0,
       executionTime,
+      truncated: result.truncated,
       metadata:
         typedData && typedData.length > 0 && typedData[0]
           ? {
@@ -454,10 +461,17 @@ const executeSqlResponseFormatter = (
   // Format the result as a table-like JSON representation
   const resultJson = JSON.stringify(result.data, null, 2);
 
+  // Surface pagination truncation so callers (including LLMs consuming the
+  // text block) know the result is a prefix of the full set — otherwise
+  // downstream analysis operates on silently-clipped data.
+  const truncationNotice = result.truncated
+    ? `\n\n⚠️  Result truncated at ${result.rowCount} rows (IBMI_PAGINATION_MAX_ROWS cap). Raise the cap or narrow the query to see more.`
+    : "";
+
   return [
     {
       type: "text",
-      text: `SQL query executed successfully.\n\nRows returned: ${result.rowCount}\nExecution time: ${result.executionTime}ms\n\nResults:\n${resultJson}`,
+      text: `SQL query executed successfully.\n\nRows returned: ${result.rowCount}\nExecution time: ${result.executionTime}ms${truncationNotice}\n\nResults:\n${resultJson}`,
     },
   ];
 };

--- a/packages/server/src/ibmi-mcp-server/utils/config/toolFactory.ts
+++ b/packages/server/src/ibmi-mcp-server/utils/config/toolFactory.ts
@@ -278,28 +278,19 @@ export class SQLToolFactory {
     // Check for IBM i authentication context
     const authInfo = authContext.getStore()?.authInfo;
 
-    // rowsToFetch wins over fetchAllRows. A deliberate row cap should never
-    // be silently overridden by an unbounded fetch, so we only take the
-    // paginated path when fetchAllRows is the sole directive.
-    if (fetchAllRows && rowsToFetch !== undefined) {
-      logger.warning(
-        {
-          ...context,
-          sourceName,
-          rowsToFetch,
-          fetchAllRows: true,
-        },
-        "Both rowsToFetch and fetchAllRows are set; honoring rowsToFetch and ignoring fetchAllRows (safer default).",
-      );
-    }
-
-    if (fetchAllRows && rowsToFetch === undefined) {
+    // fetchAllRows is the pagination *policy* ("keep paging until done");
+    // rowsToFetch (when set) is the per-fetch *size* in that mode. When
+    // fetchAllRows is unset, rowsToFetch is the single-shot row cap.
+    // Unset rowsToFetch falls through to DEFAULT_PAGE_SIZE at the service
+    // layer.
+    if (fetchAllRows) {
       logger.debug(
         {
           ...context,
           sourceName,
           routingMode: authInfo?.ibmiToken ? "authenticated" : "environment",
           fetchMode: "paginated-all-rows",
+          pageSize: rowsToFetch,
         },
         "Executing SQL with fetchAllRows via pagination path",
       );
@@ -310,7 +301,7 @@ export class SQLToolFactory {
             sql,
             parameters,
             context,
-            undefined,
+            rowsToFetch,
             securityConfig,
           )
         : await this.sourceManager.executeQueryWithPagination(
@@ -318,7 +309,7 @@ export class SQLToolFactory {
             sql,
             parameters,
             context,
-            undefined,
+            rowsToFetch,
             securityConfig,
           );
 

--- a/packages/server/tests/ibmi-mcp-server/utils/config/toolFactory.pagination.test.ts
+++ b/packages/server/tests/ibmi-mcp-server/utils/config/toolFactory.pagination.test.ts
@@ -1,18 +1,22 @@
 /**
- * @fileoverview Precedence tests for SQLToolFactory fetch controls.
+ * @fileoverview Composition tests for SQLToolFactory fetch controls.
  *
- * Verifies the rowsToFetch vs fetchAllRows decision in
- * SQLToolFactory.executeWithAuthRouting (issue #139 follow-up):
- *   - rowsToFetch alone  → executeQuery(rowsToFetch)
- *   - fetchAllRows alone → executeQueryWithPagination
- *   - both set           → executeQuery(rowsToFetch) + WARN logged,
- *                          executeQueryWithPagination NOT called
+ * Verifies the rowsToFetch / fetchAllRows decision in
+ * SQLToolFactory.executeWithAuthRouting:
+ *   - rowsToFetch alone        → executeQuery(rowsToFetch)
+ *   - fetchAllRows alone       → executeQueryWithPagination, fetchSize undefined
+ *   - both set                 → executeQueryWithPagination, fetchSize = rowsToFetch
+ *   - neither set              → executeQuery with no explicit size
+ *
+ * Replaces the prior precedence rule ("rowsToFetch wins when both are set")
+ * with composable semantics: fetchAllRows is the pagination policy,
+ * rowsToFetch (when set alongside) is the per-fetch page size.
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-// Override the global logger no-op mock with spies so we can assert the warn.
-// vi.hoisted lets us reference these symbols from the hoisted vi.mock factory.
+// Replace the module-level logger with spies so we can assert no warnings
+// are emitted now that the precedence collision no longer exists.
 const { warningSpy } = vi.hoisted(() => ({ warningSpy: vi.fn() }));
 
 vi.mock("../../../../src/utils/internal/logger.js", () => ({
@@ -36,9 +40,7 @@ vi.mock("../../../../src/utils/scheduling/index.js", () => ({
 import { SQLToolFactory } from "../../../../src/ibmi-mcp-server/utils/config/toolFactory.js";
 import type { SourceManager } from "../../../../src/ibmi-mcp-server/services/sourceManager.js";
 
-/**
- * Minimal mapepire-compatible QueryResult for the executeQuery path.
- */
+/** Minimal mapepire-compatible QueryResult for the single-shot path. */
 function makeExecuteResult() {
   return {
     success: true,
@@ -54,9 +56,7 @@ function makeExecuteResult() {
   };
 }
 
-/**
- * Minimal paginated result shape consumed by toolFactory at lines 312-325.
- */
+/** Minimal paginated result shape consumed by toolFactory's adapter. */
 function makePaginatedResult() {
   return {
     success: true,
@@ -64,13 +64,13 @@ function makePaginatedResult() {
     metadata: { columns: [] },
     sql_rc: 0,
     execution_time: 1,
+    truncated: false,
   };
 }
 
 /**
  * Builds a stub SourceManager that exposes spied versions of the two methods
- * the factory chooses between. Only the properties SQLToolFactory touches
- * need to be present — the rest of the SourceManager surface is unused here.
+ * the factory chooses between.
  */
 function makeStubSourceManager() {
   const executeQuery = vi.fn().mockResolvedValue(makeExecuteResult());
@@ -84,12 +84,12 @@ function makeStubSourceManager() {
   return { stub, executeQuery, executeQueryWithPagination };
 }
 
-describe("SQLToolFactory fetch-control precedence", () => {
+describe("SQLToolFactory fetch-control composition", () => {
   beforeEach(() => {
     warningSpy.mockClear();
   });
 
-  it("only rowsToFetch → executeQuery called with rowsToFetch, no pagination", async () => {
+  it("rowsToFetch alone → executeQuery called with rowsToFetch, no pagination", async () => {
     const { stub, executeQuery, executeQueryWithPagination } =
       makeStubSourceManager();
     SQLToolFactory.initialize(stub);
@@ -113,7 +113,7 @@ describe("SQLToolFactory fetch-control precedence", () => {
     expect(warningSpy).not.toHaveBeenCalled();
   });
 
-  it("only fetchAllRows → executeQueryWithPagination called, no executeQuery", async () => {
+  it("fetchAllRows alone → executeQueryWithPagination called, fetchSize undefined", async () => {
     const { stub, executeQuery, executeQueryWithPagination } =
       makeStubSourceManager();
     SQLToolFactory.initialize(stub);
@@ -131,11 +131,15 @@ describe("SQLToolFactory fetch-control precedence", () => {
     );
 
     expect(executeQueryWithPagination).toHaveBeenCalledTimes(1);
+    // Signature: (sourceName, query, params, context, fetchSize, securityConfig)
+    // fetchSize is the 5th positional argument (index 4).
+    const args = executeQueryWithPagination.mock.calls[0];
+    expect(args[4]).toBeUndefined();
     expect(executeQuery).not.toHaveBeenCalled();
     expect(warningSpy).not.toHaveBeenCalled();
   });
 
-  it("both set → rowsToFetch wins, fetchAllRows ignored, WARN emitted", async () => {
+  it("both set → executeQueryWithPagination called, fetchSize = rowsToFetch", async () => {
     const { stub, executeQuery, executeQueryWithPagination } =
       makeStubSourceManager();
     SQLToolFactory.initialize(stub);
@@ -152,18 +156,37 @@ describe("SQLToolFactory fetch-control precedence", () => {
       true,
     );
 
+    expect(executeQueryWithPagination).toHaveBeenCalledTimes(1);
+    const args = executeQueryWithPagination.mock.calls[0];
+    expect(args[4]).toBe(500);
+    expect(executeQuery).not.toHaveBeenCalled();
+    // No warning — the two fields compose, there's no collision anymore.
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+
+  it("neither set → executeQuery called without an explicit row cap", async () => {
+    const { stub, executeQuery, executeQueryWithPagination } =
+      makeStubSourceManager();
+    SQLToolFactory.initialize(stub);
+
+    await SQLToolFactory.executeStatementWithParameters(
+      "t",
+      "ibmi",
+      "SELECT 1",
+      {},
+      [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+
     expect(executeQuery).toHaveBeenCalledTimes(1);
     const args = executeQuery.mock.calls[0];
-    expect(args[args.length - 1]).toBe(500);
+    // The last argument in the no-rowsToFetch branch is the context, not a
+    // number — assert we did not pass a numeric cap.
+    expect(typeof args[args.length - 1]).not.toBe("number");
     expect(executeQueryWithPagination).not.toHaveBeenCalled();
-
-    expect(warningSpy).toHaveBeenCalledTimes(1);
-    const [logCtx, logMsg] = warningSpy.mock.calls[0] as [
-      Record<string, unknown>,
-      string,
-    ];
-    expect(logCtx).toMatchObject({ rowsToFetch: 500, fetchAllRows: true });
-    expect(logMsg).toMatch(/rowsToFetch/);
-    expect(logMsg).toMatch(/fetchAllRows/);
+    expect(warningSpy).not.toHaveBeenCalled();
   });
 });

--- a/tools/README.md
+++ b/tools/README.md
@@ -688,14 +688,24 @@ The `tableFormat` and `maxDisplayRows` fields are optional. If omitted, the tool
 
 > **Note:** These controls affect how many rows are **fetched from the database**, which is distinct from `maxDisplayRows` above (that only truncates the rendered markdown table).
 
+The two fields **compose**: `fetchAllRows` is the pagination *policy* ("keep paging until the result is exhausted"); `rowsToFetch`, when set, is the per-fetch *size* in that mode, or a single-shot row cap when `fetchAllRows` is off.
+
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `rowsToFetch` | integer (≥ 1) | mapepire default (100) | Maximum rows fetched from the database in a single call. Use when your SQL uses `FETCH FIRST :limit ROWS ONLY` and you need more than 100. Takes precedence over `fetchAllRows` when both are set. |
-| `fetchAllRows` | boolean | `false` | When `true`, fetches all rows using paginated fetches (bounded by an internal ~30k safety cap). Ignored if `rowsToFetch` is also set. |
+| `rowsToFetch` | integer (≥ 1) | mapepire default (100) | With `fetchAllRows: true`, the number of rows per `fetchMore` call. Without `fetchAllRows`, a single-shot cap on `FETCH FIRST :limit ROWS ONLY` style queries. |
+| `fetchAllRows` | boolean | `false` | When `true`, paginate until the database reports `is_done` or the safety ceiling (`IBMI_PAGINATION_MAX_ROWS`, default 30000) is reached. |
 
-**Precedence:** If both are set, `rowsToFetch` wins and `fetchAllRows` is ignored (a warning is logged). Rationale: a deliberate row cap should never be silently overridden by an unbounded fetch.
+**Three useful combinations:**
 
-**⚠️ Context-bloat warning:** Large result sets consume LLM context quickly. Prefer `rowsToFetch` with a deliberate small value; only use `fetchAllRows` for small catalogs or when the LLM has explicitly requested a full dump. A warning is logged when `rowsToFetch` exceeds 10,000.
+| Config | Behavior |
+|---|---|
+| `rowsToFetch: N` alone | Single-shot `execute(N)` — up to N rows returned |
+| `fetchAllRows: true` alone | Paginate, `IBMI_PAGINATION_DEFAULT_PAGE_SIZE` (default 1000) per fetch |
+| `fetchAllRows: true, rowsToFetch: N` | Paginate, **N rows per fetch** — useful for wide rows where the default page is too large |
+
+The per-call row ceiling is controlled by the `IBMI_PAGINATION_MAX_ROWS` env var (default 30000). When a paginated result hits the cap, the server truncates the result set and emits a warning log; the CLI surfaces the truncation in its output footer.
+
+**⚠️ Context-bloat warning:** Large result sets consume LLM context quickly. Prefer `rowsToFetch` with a deliberate small value; only use `fetchAllRows` for small catalogs or when the caller has explicitly requested a full dump.
 
 **Example — lift the 100-row cap for a single call:**
 
@@ -723,10 +733,25 @@ tools:
   list_all_schemas:
     source: ibmi
     description: "List every schema (small catalog)"
-    fetchAllRows: true      # paginates until is_done, bounded by safety cap
+    fetchAllRows: true      # paginates until is_done, bounded by IBMI_PAGINATION_MAX_ROWS
     statement: |
       SELECT SCHEMA_NAME FROM QSYS2.SYSSCHEMAS
       ORDER BY SCHEMA_NAME
+```
+
+**Example — paginate with a custom page size (wide rows):**
+
+```yaml
+tools:
+  export_all_columns:
+    source: ibmi
+    description: "Stream every column of every table in SAMPLE"
+    fetchAllRows: true      # paginate
+    rowsToFetch: 500        # 500 rows per fetchMore call (smaller pages for wider rows)
+    statement: |
+      SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, LENGTH
+      FROM QSYS2.SYSCOLUMNS2
+      WHERE TABLE_SCHEMA = 'SAMPLE'
 ```
 
 ---

--- a/tools/sample/fetch-rows-verification.yaml
+++ b/tools/sample/fetch-rows-verification.yaml
@@ -1,4 +1,4 @@
-# Verification tools for rowsToFetch / fetchAllRows (Issue #139)
+# Verification tools for rowsToFetch / fetchAllRows composition
 #
 # QSYS2.SYSCOLUMNS2 is a large catalog view on every IBM i system — it lists
 # every column of every table the caller can see, so it's guaranteed to have
@@ -7,7 +7,8 @@
 #   - syscolumns_default    → no row config, exercises mapepire's 100-row default
 #   - syscolumns_limited    → rowsToFetch: 500, exercises the Query.execute(n) path
 #   - syscolumns_fetch_all  → fetchAllRows: true, exercises the pagination path
-#   - syscolumns_both       → both set; fetchAllRows must win and rowsToFetch is ignored
+#   - syscolumns_both       → both set; paginates with rowsToFetch as the
+#                             per-fetch page size (composition)
 
 sources:
   ibmi-verify:
@@ -78,13 +79,15 @@ tools:
   syscolumns_both:
     source: ibmi-verify
     description: >
-      Precedence test — both rowsToFetch and fetchAllRows are set.
-      rowsToFetch must win; fetchAllRows is silently ignored.
+      Composition test — both rowsToFetch and fetchAllRows are set.
+      Paginates until the result is exhausted (or the IBMI_PAGINATION_MAX_ROWS
+      cap is hit), using rowsToFetch as the per-fetch page size. The server
+      debug log should show fetchCount > 1 with fetchSize = 500.
     statement: |
       SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, LENGTH
       FROM QSYS2.SYSCOLUMNS2
       WHERE TABLE_SCHEMA = 'QSYS2'
-    rowsToFetch: 10
+    rowsToFetch: 500
     fetchAllRows: true
     security:
       readOnly: true
@@ -93,7 +96,7 @@ tools:
       idempotentHint: true
       domain: "verification"
       category: "fetch-rows"
-      title: "SYSCOLUMNS2 (both set → fetchAllRows wins)"
+      title: "SYSCOLUMNS2 (paginate, 500 rows/fetch)"
 
 toolsets:
   fetch_rows_verification:


### PR DESCRIPTION
## Summary

Consolidates the fetch-limit UX introduced in 0.5.0 before downstream adoption locks in the current behavior. Three fixes in one PR, seven atomic commits:

- **`rowsToFetch` and `fetchAllRows` compose instead of colliding.** When both are set, `rowsToFetch` now becomes the per-fetch page size (was silently ignored with a warning log). Every combination of the two fields means something unambiguous — the "takes precedence" rule disappears.
- **Pagination safety ceiling is row-based, not iteration-based.** The loop now terminates at `IBMI_PAGINATION_MAX_ROWS` rows of accumulated data rather than at 100 `fetchMore` iterations, so the effective row ceiling is stable regardless of per-fetch page size. Previously a larger page size implicitly granted a proportionally larger cap.
- **Four copies of `fetchSize = 300` and `execute_sql`'s hardcoded `1000` all collapse into two env-tunable constants.** `execute_sql`'s effective ceiling drops from ~100,000 to the documented 30,000 — aligning with every YAML tool.

## The new contract

| YAML | Behavior |
|---|---|
| Neither field set | Mapepire default — single-shot `execute()`, 100 rows |
| `rowsToFetch: N` alone | Single-shot `execute(N)`, up to N rows |
| `fetchAllRows: true` alone | Paginate, `IBMI_PAGINATION_DEFAULT_PAGE_SIZE` per fetch |
| `fetchAllRows: true, rowsToFetch: N` | Paginate, **N rows per fetch** |

## New env vars

```
IBMI_PAGINATION_DEFAULT_PAGE_SIZE=1000   # rows per fetchMore call
IBMI_PAGINATION_MAX_ROWS=30000           # safety ceiling on total rows returned
```

Rationale: 1000 × 30 round-trips ≈ 3s tail latency for a cap-hit paginated query. 30000 rows ≈ 3-6M tokens, already beyond every current LLM context window — the cap means "you shouldn't be returning more than this in one shot."

## UX

When the cap is hit, the server emits a warning log and flags the response. The CLI `tool run` footer now shows `(result capped — raise IBMI_PAGINATION_MAX_ROWS or narrow the query)`. Previously truncation was silent.

## Commit sequence

Seven atomic commits, DCO-signed, each passing tests in isolation. The refactors (1-3) land before the semantic change (4), so `git bisect` can distinguish "code got reorganized" from "behavior changed":

1. `refactor(config): add pagination constants and env vars`
2. `refactor(services): read DEFAULT_PAGE_SIZE from config`
3. `refactor(services): row-based pagination cap`
4. `feat(tools): compose rowsToFetch and fetchAllRows`
5. `refactor(tools): execute_sql inherits pagination defaults`
6. `feat(cli): surface pagination truncation in tool output`
7. `docs: consolidate fetch-limit UX and update tests`

## Migration

None for YAML configs that set only one of the two fields. YAML configs that set **both** now paginate with the custom page size instead of silently ignoring `fetchAllRows` — if that transition is undesirable, remove `fetchAllRows`. Callers relying on `execute_sql` to return >30,000 rows in one call should raise `IBMI_PAGINATION_MAX_ROWS` explicitly.

## Test plan

- [x] `npm run typecheck` — clean across both packages
- [x] `npm run lint` — clean
- [x] `npm run build` — clean across both packages
- [x] `npm run validate -- --tools tools/sample/fetch-rows-verification.yaml` — passes
- [x] New `toolFactory.pagination.test.ts` — 4/4 cases pass (single-shot, paginate-default, composition, neither)
- [x] Existing `baseConnectionPool.test.ts` — 24/24 pass
- [ ] **Live Mapepire check** — run `syscolumns_both` from `tools/sample/fetch-rows-verification.yaml`, confirm debug logs show `fetchCount > 1` with `fetchSize = 500`
- [ ] **Cap-hit check** — `IBMI_PAGINATION_MAX_ROWS=5000 ibmi tool run syscolumns_fetch_all`, confirm exactly 5000 rows returned and truncation footer displayed
- [ ] **`execute_sql` alignment** — same env override, run `execute_sql` with a large SELECT, confirm the same 5000-row cap applies (not the old ~100k)

## Known pre-existing issue

`tests/unit/tools/defaultTools.test.ts`, `rateLimiter.integration.test.ts`, and `packages/cli/tests/formatters/output.test.ts` fail with `node-cron` ESM path resolution errors when vitest runs inside `.claude/worktrees/*`. Same failure on `main` — orthogonal to this PR, worth a separate issue.